### PR TITLE
Performance enhancements to broadcast operation for min/max kernels.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
@@ -68,20 +68,59 @@ struct MinimumOp {
 
 }  // namespace maximum_minimum
 
-#if defined(HIFI5)
 namespace hifi {
 
-template <typename data_type, typename op_type>
-TfLiteStatus TFLiteOperation(TfLiteContext* context, TfLiteNode* node,
-                     const OpContext& op_context);
+enum class basic_op {
+  no_op,
+  min,
+  max
+};
 
-template <typename T, typename Op, int N = 4>
-void MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const T* input1_data,
-                                        const RuntimeShape& unextended_input2_shape, const T* input2_data,
-                                        const RuntimeShape& unextended_output_shape,       T* output_data,
-                                        Op op);
+template <typename data_type>
+TfLiteStatus TFLiteOperation( TfLiteContext* context, TfLiteNode* node,
+                              const OpContext& op_context,
+                              basic_op operation);
+
+template <typename T, int N = 4>
+int MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const T* input1_data,
+                             const RuntimeShape& unextended_input2_shape, const T* input2_data,
+                             const RuntimeShape& unextended_output_shape,       T* output_data,
+                             hifi::basic_op op);
+
+template <typename data_type>
+int ExecElemKernel( hifi::basic_op op, data_type *out_data,
+                    const data_type *in1_data, const data_type *in2_data, size_t num_Elements);
+
 }  // namespace hifi
-#endif // defined(HIFI5)
+
+/* Execute an element-wise kernel depending on the type specified by elem_op.
+ * For now, the only data_type supported is int8_t
+ * hifi::basic_op::min -> xa_nn_elm_min_8x8_8
+ * hifi::basic_op::max -> xa_nn_elm_max_8x8_8
+ */
+template <typename data_type>
+int hifi::ExecElemKernel( hifi::basic_op elem_op, data_type *out_data,
+                          const data_type *in1_data, const data_type *in2_data,
+                          size_t num_Elements) {
+  int err = 0;
+  
+  if(!std::is_same<data_type, int8_t>::value){
+      err = -1;
+  } else {
+    switch(elem_op){
+      case hifi::basic_op::min :
+        err = xa_nn_elm_min_8x8_8(out_data, in1_data, in2_data, num_Elements);
+        break;
+      case hifi::basic_op::max :
+        err = xa_nn_elm_max_8x8_8(out_data, in1_data, in2_data, num_Elements);
+        break;
+      default :
+        err = -1;
+    }
+  }
+
+  return err;
+}
 
 template <typename data_type, typename op_type>
 void TFLiteOperation(TfLiteContext* context, TfLiteNode* node,
@@ -96,105 +135,123 @@ void TFLiteOperation(TfLiteContext* context, TfLiteNode* node,
       op_type::template op<data_type>);
 }
 
-#if defined(HIFI5)
-template <typename data_type, typename op_type, int N>
-void hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const data_type *input1_data,
-                                    const RuntimeShape& unextended_input2_shape, const data_type *input2_data,
-                                    const RuntimeShape& unextended_output_shape,       data_type *output_data,
-                                    op_type op) {
+/*
+ * Invoke element-wise kernels if the shapes match, else,
+ * call hifi::MaximumMinimumBroadcast(...)
+ */
+template <typename data_type>
+TfLiteStatus hifi::TFLiteOperation(
+    TfLiteContext* context, TfLiteNode* node,
+    const OpContext& op_context, hifi::basic_op elem_op) {
 
-    TFLITE_DCHECK_LE(unextended_input1_shape.DimensionsCount(), N);
-    TFLITE_DCHECK_LE(unextended_input2_shape.DimensionsCount(), N);
-    TFLITE_DCHECK_LE(unextended_output_shape.DimensionsCount(), N);
+  int err = 0;
 
-    NdArrayDesc<N> input1_desc;
-    NdArrayDesc<N> input2_desc;
-    NdArrayDesc<N> output_desc;
-
-    NdArrayDescsForElementwiseBroadcast(
-        unextended_input1_shape, unextended_input2_shape, &input1_desc, &input2_desc);
-
-    CopyDimsToDesc(RuntimeShape::ExtendedShape(N, unextended_output_shape),
-                   &output_desc);
-
-    if(std::is_same<op_type, MaximumOp>::value) {
-      xa_nn_elm_max_4D_Bcast_8x8_8( output_data, output_desc.extents,
-                                    input1_data, input1_desc.strides,
-                                    input2_data, input2_desc.strides);
-    }
-
-    if(std::is_same<op_type, MinimumOp>::value) {
-      xa_nn_elm_min_4D_Bcast_8x8_8( output_data, output_desc.extents,
-                                    input1_data, input1_desc.strides,
-                                    input2_data, input2_desc.strides);
-
-    }
-}
-
-
-template <typename data_type, typename op_type>
-TfLiteStatus hifi::TFLiteOperation(TfLiteContext* context, TfLiteNode* node,
-                     const OpContext& op_context) {
-  
   const RuntimeShape &unextended_input1_shape = tflite::micro::GetTensorShape(op_context.input1),
                      &unextended_input2_shape = tflite::micro::GetTensorShape(op_context.input2),
                      &unextended_output_shape = tflite::micro::GetTensorShape(op_context.output);
 
-  int err = 0;
-  
-
-  if(unextended_input1_shape == unextended_input2_shape){
-    if(std::is_same<op_type, MaximumOp>::value) {
-      xa_nn_elm_max_8x8_8( tflite::micro::GetTensorData<data_type>(op_context.output),
-                           tflite::micro::GetTensorData<data_type>(op_context.input1),
-                           tflite::micro::GetTensorData<data_type>(op_context.input2),
-                           unextended_output_shape.FlatSize());
-      TF_LITE_ENSURE(context, err == 0);
-    }
-    if(std::is_same<op_type, MinimumOp>::value) {
-      xa_nn_elm_min_8x8_8( tflite::micro::GetTensorData<data_type>(op_context.output),
-                           tflite::micro::GetTensorData<data_type>(op_context.input1),
-                           tflite::micro::GetTensorData<data_type>(op_context.input2),
-                           unextended_output_shape.FlatSize());
-      TF_LITE_ENSURE(context, err == 0);
-    }
+  if (unextended_input1_shape == unextended_input2_shape) {
+    err = hifi::ExecElemKernel<data_type>( elem_op,
+                    tflite::micro::GetTensorData<data_type>(op_context.output),
+                    tflite::micro::GetTensorData<data_type>(op_context.input1),
+                    tflite::micro::GetTensorData<data_type>(op_context.input2),
+                    unextended_output_shape.FlatSize());
   } else {
-    op_type maxmin_type;
-    hifi::MaximumMinimumBroadcast(
-        tflite::micro::GetTensorShape(op_context.input1), tflite::micro::GetTensorData<data_type>(op_context.input1),
-        tflite::micro::GetTensorShape(op_context.input2), tflite::micro::GetTensorData<data_type>(op_context.input2),
-        tflite::micro::GetTensorShape(op_context.output), tflite::micro::GetTensorData<data_type>(op_context.output),
-        maxmin_type);
+    err = hifi::MaximumMinimumBroadcast(
+            tflite::micro::GetTensorShape(op_context.input1), tflite::micro::GetTensorData<data_type>(op_context.input1),
+            tflite::micro::GetTensorShape(op_context.input2), tflite::micro::GetTensorData<data_type>(op_context.input2),
+            tflite::micro::GetTensorShape(op_context.output), tflite::micro::GetTensorData<data_type>(op_context.output),
+            elem_op);
   }
-  
+
+  TF_LITE_ENSURE_EQ(context, err, 0);
+
   return kTfLiteOk;
 }
-#endif // defined(HIFI5)
+
+template <typename data_type, int N>
+int hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const data_type *input1_data,
+                                   const RuntimeShape& unextended_input2_shape, const data_type *input2_data,
+                                   const RuntimeShape& unextended_output_shape,       data_type *output_data,
+                                   hifi::basic_op op) {
+
+  int err = 0;
+  const int numDims = (N<=4) ? 4 :
+                          (N<=8) ? 8 : 0;
+
+  TFLITE_DCHECK_LE(unextended_input1_shape.DimensionsCount(), N);
+  TFLITE_DCHECK_LE(unextended_input2_shape.DimensionsCount(), N);
+  TFLITE_DCHECK_LE(unextended_output_shape.DimensionsCount(), N);
+
+  const RuntimeShape extended_input1_shape = RuntimeShape::ExtendedShape(numDims, unextended_input1_shape);
+  const RuntimeShape extended_input2_shape = RuntimeShape::ExtendedShape(numDims, unextended_input2_shape);
+  const RuntimeShape extended_output_shape = RuntimeShape::ExtendedShape(numDims, unextended_output_shape);
+
+  NdArrayDesc<numDims> input1_desc;
+  NdArrayDesc<numDims> input2_desc;
+  NdArrayDesc<numDims> output_desc;
+
+  NdArrayDescsForElementwiseBroadcast( unextended_input1_shape, unextended_input2_shape,
+                                                  &input1_desc,            &input2_desc );
+
+  CopyDimsToDesc(extended_output_shape, &output_desc);
+
+  if ( (extended_input1_shape != extended_output_shape) &&
+       (extended_input2_shape == extended_output_shape)     ) {         // input 1 needs broadcast
+
+    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                       
+            input1_data, extended_input1_shape.DimsData(), N);          // broadcast input 1 into output_data buffer
+
+    err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
+                   output_data, input2_data,
+                   extended_output_shape.FlatSize());
+
+  } else if( (extended_input1_shape == extended_output_shape) &&
+             (extended_input2_shape != extended_output_shape)     ) {   // input 2 needs broadcast
+
+    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                        
+            input2_data, extended_input2_shape.DimsData(), N);          // broadcast input 2 into output_data buffer
+
+    err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
+                   input1_data, output_data,
+                   extended_output_shape.FlatSize());
+  } else {
+
+    /* Both inputs need broadcast.
+     * Call any of the xa_nn_elm_[min,max]_[4D,8D]_Bcast_8x8_8(...) kernels.
+     * All these kernels have same the same function signature.
+     */
+
+    decltype(&xa_nn_elm_min_4D_Bcast_8x8_8) kernel = NULL;
+
+    if(numDims == 4){
+      kernel = (op == hifi::basic_op::min) ? xa_nn_elm_min_4D_Bcast_8x8_8 :
+                 (op == hifi::basic_op::max) ? xa_nn_elm_max_4D_Bcast_8x8_8 : NULL;
+    }else if(numDims == 8){
+      kernel = (op == hifi::basic_op::min) ? xa_nn_elm_min_8D_Bcast_8x8_8 :
+                 (op == hifi::basic_op::max) ? xa_nn_elm_max_8D_Bcast_8x8_8 : NULL;
+    }
+
+    if(kernel!=NULL){
+      err = kernel(output_data, output_desc.extents,
+                   input1_data, input1_desc.strides,
+                   input2_data, input2_desc.strides );
+    }
+  }
+
+  return err;
+}
 
 template <KernelType kernel_type, typename OpType>
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   OpContext op_context(context, node);
 
-#if defined(HIFI5)
-  if ( (kernel_type == kHiFi) &&
-      (op_context.output->type == kTfLiteInt8) )
-  {
-    switch (op_context.output->type) {
-      case kTfLiteInt8:
-        hifi::TFLiteOperation<int8_t, OpType>(context, node, op_context);
-        break;
-      default:
-        TF_LITE_KERNEL_LOG(context,
-                           "Type %s (%d) is not supported by Maximum/Minimum.",
-                           TfLiteTypeGetName(op_context.output->type),
-                           op_context.output->type);
-        return kTfLiteError;
-    }
-  } else 
-#endif // defined(HIFI5)
-  if ((kernel_type == kReference)  ||
-        ((kernel_type == kHiFi)))
-  {
+  if (kernel_type == kReference || kernel_type == kHiFi) {
+
+    hifi::basic_op operation =
+        std::is_same<OpType, MinimumOp>::value ? hifi::basic_op::min :
+            std::is_same<OpType, MaximumOp>::value ? hifi::basic_op::max :
+                hifi::basic_op::no_op;
 
     switch (op_context.output->type) {
       case kTfLiteFloat32:
@@ -204,7 +261,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         TFLiteOperation<uint8_t, OpType>(context, node, op_context);
         break;
       case kTfLiteInt8:
-        TFLiteOperation<int8_t, OpType>(context, node, op_context);
+        if (kernel_type == kHiFi) {
+          hifi::TFLiteOperation<int8_t>(context, node, op_context, operation);
+        } else {
+          TFLiteOperation<int8_t, OpType>(context, node, op_context);
+        }
         break;
       case kTfLiteInt32:
         TFLiteOperation<int32_t, OpType>(context, node, op_context);

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -75,7 +75,8 @@ ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "hifi5"))
     $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_elm_mul_f32.c \
     $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_elm_add_quant8.c \
     $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_elm_add_f32.c \
-    $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_elm_sub_quant8.c
+    $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_elm_sub_quant8.c \
+    $(NNLIB_PATH)/algo/kernels/basic/hifi5/xa_nn_broadcast_8_8.c
 
   INCLUDES += \
     -I$(NNLIB_PATH)/ \


### PR DESCRIPTION
If only one input needs broadcast, use new (fast) kernel _xa_nn_broadcast_8_8()_ to broadcast and then call element-wise min/max kernel.
Else, revert to original _xa_nn_elm_\_[_min_,_max_]\_[_4D_,_8D_]\__Bcast_8x8_8()_ kernels.