### PR TITLE
Mul operator kTfLiteFloat32 fix:

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/mul.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/mul.cc
@@ -139,7 +139,7 @@ TfLiteStatus MulEval(TfLiteContext* context, TfLiteNode* node) {
         EvalMulQuantizedReference(context, node, data, input1, input2, output);
       break;
     case kTfLiteFloat32:
-#if defined(HIFI5) || defined(HIFI4)
+#if HIFI_VFPU 
       if (!need_broadcast) 
         EvalMulFloatHiFi(context, node, params, data, input1, input2, output);
       else


### PR DESCRIPTION
Added #if HIFI_VFPU switch. This fixed the non-VFPU builds.