### PR TITLE
Xtensa makefile clean-up.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -7,7 +7,8 @@ MICROLITE_CC_KERNEL_SRCS += \
   tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
   tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc \
   tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
-  tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc
+  tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
+  tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc
 
 ifeq ($(TARGET_ARCH), hifi5)
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi5)

--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -99,15 +99,3 @@ EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/network_tester/Makefile.inc
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 MICRO_LITE_EXAMPLE_TESTS += $(shell find third_party/xtensa/examples/ -name Makefile.inc)
-
-# Needed for LSTM support.
-MICROLITE_CC_KERNEL_SRCS := $(MICROLITE_CC_KERNEL_SRCS) \
-tensorflow/lite/kernels/internal/reference/portable_tensor_utils.cc \
-tensorflow/lite/kernels/kernel_util.cc
-
-ifeq ($(OPTIMIZED_KERNEL_DIR), xtensa)
-  MICROLITE_CC_KERNEL_SRCS := $(MICROLITE_CC_KERNEL_SRCS) \
-  tensorflow/lite/micro/kernels/xtensa/lstm_eval.cc \
-  tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc \
-  tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
-endif


### PR DESCRIPTION
Did clean-up related to LSTM support. As LSTM ref is now available in TFLM, removed redundant LSTM specific section from xtensa_makefile.inc.