### PR TITLE
Integrated new kernels introduced in HiFi5 NNLib v1.8.0 and HiFi4 NNL…

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/add.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/add.cc
@@ -105,9 +105,11 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
   op_params.output_shift = data->output_shift;
   SetActivationParams(data->output_activation_min, data->output_activation_max,
                       &op_params);
+#if !(defined(HIFI4) || defined(HIFI5))
   bool need_broadcast = reference_ops::ProcessBroadcastShapes(
       tflite::micro::GetTensorShape(input1),
       tflite::micro::GetTensorShape(input2), &op_params);
+#endif
 
   switch (output->type) {
     case kTfLiteInt8: {
@@ -116,8 +118,31 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
           *(reinterpret_cast<XtensaAddOpData*>(node->user_data));
       AddEvalQuantizedVision(context, node, *params, op_data, input1, input2,
                              output);
-#else   // if defined(VISION_P6)
+#elif defined(HIFI4) || defined(HIFI5) // #if defined(VISION_P6)
+      int err;
+      const RuntimeShape extended_input1_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
 
+      err = xa_nn_elm_add_broadcast_4D_asym8sxasym8s_asym8s(
+          tflite::micro::GetTensorData<int8_t>(output),
+          extended_output_shape.DimsData(), op_params.output_offset,
+          op_params.output_shift, op_params.output_multiplier,
+          op_params.quantized_activation_min,
+          op_params.quantized_activation_max,
+          tflite::micro::GetTensorData<int8_t>(input1),
+          extended_input1_shape.DimsData(), op_params.input1_offset,
+          op_params.input1_shift, op_params.input1_multiplier,
+          tflite::micro::GetTensorData<int8_t>(input2),
+          extended_input2_shape.DimsData(),
+          op_params.input2_offset, op_params.input2_shift,
+          op_params.input2_multiplier, op_params.left_shift);
+
+      TF_LITE_ENSURE(context, err == 0);
+#else // #if defined(VISION_P6)
       if (need_broadcast) {
         reference_integer_ops::BroadcastAdd4DSlow(
             op_params, tflite::micro::GetTensorShape(input1),
@@ -127,26 +152,6 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int8_t>(output));
       } else {
-#if defined(HIFI4) || defined(HIFI5)
-        int err;
-        const RuntimeShape& input1_shape = tflite::micro::GetTensorShape(input1);
-        const RuntimeShape& input2_shape = tflite::micro::GetTensorShape(input2);
-        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-        const int flat_size =
-            MatchingElementsSize(input1_shape, input2_shape, output_shape);
-
-        err = xa_nn_elm_add_asym8sxasym8s_asym8s(
-            tflite::micro::GetTensorData<int8_t>(output), op_params.output_offset,
-            op_params.output_shift, op_params.output_multiplier,
-            op_params.quantized_activation_min,
-            op_params.quantized_activation_max, tflite::micro::GetTensorData<int8_t>(input1),
-            op_params.input1_offset, op_params.input1_shift,
-            op_params.input1_multiplier, tflite::micro::GetTensorData<int8_t>(input2),
-            op_params.input2_offset, op_params.input2_shift,
-            op_params.input2_multiplier, op_params.left_shift, flat_size);
-
-        TF_LITE_ENSURE(context, err == 0);
-#else
         reference_integer_ops::Add(
             op_params, tflite::micro::GetTensorShape(input1),
             tflite::micro::GetTensorData<int8_t>(input1),
@@ -154,12 +159,36 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorData<int8_t>(input2),
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI4) || defined(HIFI5)
       }
-#endif  // if (defined(VISION_P6)
+#endif // #if (defined(VISION_P6)
       break;
     }
     case kTfLiteInt16: {
+#if defined(HIFI4) || defined(HIFI5)
+      int err;
+      const RuntimeShape extended_input1_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+          RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+      err = xa_nn_elm_add_broadcast_4D_asym16sxasym16s_asym16s(
+          tflite::micro::GetTensorData<int16_t>(output),
+          extended_output_shape.DimsData(), op_params.output_offset,
+          op_params.output_shift, op_params.output_multiplier,
+          op_params.quantized_activation_min,
+          op_params.quantized_activation_max,
+          tflite::micro::GetTensorData<int16_t>(input1),
+          extended_input1_shape.DimsData(), op_params.input1_offset,
+          op_params.input1_shift, op_params.input1_multiplier,
+          tflite::micro::GetTensorData<int16_t>(input2),
+          extended_input2_shape.DimsData(),
+          op_params.input2_offset, op_params.input2_shift,
+          op_params.input2_multiplier, op_params.left_shift);
+
+      TF_LITE_ENSURE(context, err == 0);
+#else // #if defined(HIFI4) || defined(HIFI5)
       if (need_broadcast) {
         reference_ops::BroadcastAdd4DSlow(
             op_params, tflite::micro::GetTensorShape(input1),
@@ -169,44 +198,6 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
       } else {
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
-        int err;
-        const RuntimeShape& input1_shape =
-            tflite::micro::GetTensorShape(input1);
-        const RuntimeShape& input2_shape =
-            tflite::micro::GetTensorShape(input2);
-        const RuntimeShape& output_shape =
-            tflite::micro::GetTensorShape(output);
-
-	const int* inp1_shape = reinterpret_cast<const int*>(input1_shape.DimsData());
-	const int* inp2_shape = reinterpret_cast<const int*>(input2_shape.DimsData());
-	const int* op_shape = reinterpret_cast<const int*>(output_shape.DimsData());
-
-        int ii;
-        int inp1shape[4]={1, 1, 1, 1},inp2shape[4]={1, 1, 1, 1}, opshape[4]={1, 1, 1, 1};
-        for(ii=0; ii<input1_shape.DimensionsCount(); ii++){
-          inp1shape[ii] = inp1_shape[ii];
-          inp2shape[ii] = inp2_shape[ii];
-          opshape[ii] = op_shape[ii];
-        }
-        err = xa_nn_elm_add_broadcast_4D_asym16sxasym16s_asym16s(
-            tflite::micro::GetTensorData<int16_t>(output),
-	    opshape,
-            op_params.output_offset, op_params.output_shift,
-            op_params.output_multiplier, op_params.quantized_activation_min,
-            op_params.quantized_activation_max,
-            tflite::micro::GetTensorData<int16_t>(input1),
-	    inp1shape,
-            op_params.input1_offset, op_params.input1_shift,
-            op_params.input1_multiplier,
-            tflite::micro::GetTensorData<int16_t>(input2),
-	    inp2shape,
-            op_params.input2_offset, op_params.input2_shift,
-            op_params.input2_multiplier, op_params.left_shift);
-
-        TF_LITE_ENSURE(context, err == 0);
-
-#else
         reference_ops::Add(op_params, tflite::micro::GetTensorShape(input1),
                            tflite::micro::GetTensorData<int16_t>(input1),
                            tflite::micro::GetTensorShape(input2),
@@ -214,8 +205,8 @@ TfLiteStatus EvalAddQuantized(TfLiteContext* context, TfLiteNode* node,
                            tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output),
                            false);
-#endif
       }
+#endif // #if defined(HIFI4) || defined(HIFI5)
       break;
     }
     default:

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -92,7 +92,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteInt16: {
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
       ConvEvalHifi16(context, node, params, op_data, input, filter, bias,
                      output);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -96,7 +96,6 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
 TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
                             const TfLiteConvParams& params,
                             const XtensaConvOpData& data,
@@ -209,7 +208,6 @@ TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
       tflite::micro::GetTensorData<int16_t>(output));
   return kTfLiteOk;
 }
-#endif  // defined (HIFI4_INTERNAL) || defined(HIFI4)
 
 TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
                           const TfLiteConvParams& params,
@@ -329,4 +327,4 @@ TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
 }
 
 }  // namespace tflite
-#endif  // defined(HIFI4) || defined (HIFI4_INTERNAL) || defined(HIFI5)
+#endif // defined(HIFI4) || defined (HIFI4_INTERNAL) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/leaky_relu.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/leaky_relu.cc
@@ -99,7 +99,7 @@ TfLiteStatus LeakyReluEval(TfLiteContext* context, TfLiteNode* node) {
     } break;
 #endif // defined(HIFI4) || defined(HIFI5)
     case kTfLiteInt16: {
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
       const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
       const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
       const int flat_size = MatchingFlatSize(input_shape, output_shape);

--- a/tensorflow/lite/micro/kernels/xtensa/pad.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pad.cc
@@ -258,7 +258,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           constant_values == nullptr
               ? 0
               : *tflite::micro::GetTensorData<int16_t>(constant_values);
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
       /* NNLib currently only supports upto 4D input tensors */
       if (tflite::micro::GetTensorShape(input).DimensionsCount() == 4) {
         const TfLiteEvalTensor* paddings =
@@ -276,14 +276,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
             pad_value);
         if (err != 0) return kTfLiteError;
       } else {
-#endif  // HIFI4_INTERNAL || defined(HIFI4)
+#endif  // HIFI4_INTERNAL || defined(HIFI4) || defined(HIFI5)
         reference_ops::Pad(data->params, tflite::micro::GetTensorShape(input),
                            tflite::micro::GetTensorData<int16_t>(input),
                            &pad_value, tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output));
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
       }
-#endif  // HIFI4_INTERNAL || defined(HIFI4)
+#endif  // HIFI4_INTERNAL || defined(HIFI4) || defined(HIFI5)
     } break;
     case kTfLiteInt32: {
       int32_t pad_value =

--- a/tensorflow/lite/micro/kernels/xtensa/squared_difference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/squared_difference.cc
@@ -1,0 +1,286 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/binary_function.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/add.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_context.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+
+namespace tflite {
+namespace {
+constexpr int kInputTensor1 = 0;
+constexpr int kInputTensor2 = 1;
+constexpr int kOutputTensor = 0;
+
+struct OpData {
+  bool requires_broadcast;
+  ArithmeticParams arithmetic_params;
+};
+
+template <typename T>
+T SquaredDifference(T input1, T input2) {
+  const T difference = input1 - input2;
+  return difference * difference;
+}
+
+void* SquaredDifferenceInit(TfLiteContext* context, const char* buffer,
+                            size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+TfLiteStatus SquaredDifferencePrepare(TfLiteContext* context,
+                                      TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  OpData* data = reinterpret_cast<OpData*>(node->user_data);
+  data->requires_broadcast = false;
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input1 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor1);
+  TF_LITE_ENSURE(context, input1 != nullptr);
+  TfLiteTensor* input2 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor2);
+  TF_LITE_ENSURE(context, input2 != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  TF_LITE_ENSURE_TYPES_EQ(context, input1->type, input2->type);
+  output->type = input2->type;
+
+  // Ensure the quantization parameters are equivalent.
+  if (input1->type == kTfLiteInt8) {
+    const auto& input1_quantization_params = input1->params;
+    const auto& input2_quantization_params = input2->params;
+    const auto& output_quantization_params = output->params;
+    const int32_t integer_type_min = std::numeric_limits<int8_t>::min();
+    const int32_t integer_type_max = std::numeric_limits<int8_t>::max();
+    TF_LITE_ENSURE(context,
+                   input1_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   input1_quantization_params.zero_point <= integer_type_max);
+    TF_LITE_ENSURE(context,
+                   input2_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   input2_quantization_params.zero_point <= integer_type_max);
+    TF_LITE_ENSURE(context,
+                   output_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   output_quantization_params.zero_point <= integer_type_max);
+    data->arithmetic_params.input1_offset =
+        -input1_quantization_params.zero_point;
+    data->arithmetic_params.input2_offset =
+        -input2_quantization_params.zero_point;
+    data->arithmetic_params.output_offset =
+        output_quantization_params.zero_point;
+
+    // shift to make integer for scales.
+    // 7 is selected so that maximum shifted result 255^2 * (1 << (7 * 2 ))
+    // does not overflow signed 32-bit integer
+    data->arithmetic_params.left_shift = 7;
+    const double twice_max_input_scale =
+        2.0 * static_cast<double>(std::max(input1_quantization_params.scale,
+                                           input2_quantization_params.scale));
+    const double real_input1_multiplier =
+        static_cast<double>(input1_quantization_params.scale) /
+        twice_max_input_scale;
+    double real_input2_multiplier =
+        static_cast<double>(input2_quantization_params.scale) /
+        twice_max_input_scale;
+    const double real_output_multiplier =
+        (twice_max_input_scale * twice_max_input_scale) /
+        static_cast<double>((1 << data->arithmetic_params.left_shift * 2) *
+                            output_quantization_params.scale);
+    QuantizeMultiplierSmallerThanOneExp(
+        real_input1_multiplier, &data->arithmetic_params.input1_multiplier,
+        &data->arithmetic_params.input1_shift);
+    QuantizeMultiplierSmallerThanOneExp(
+        real_input2_multiplier, &data->arithmetic_params.input2_multiplier,
+        &data->arithmetic_params.input2_shift);
+    QuantizeMultiplierSmallerThanOneExp(
+        real_output_multiplier, &data->arithmetic_params.output_multiplier,
+        &data->arithmetic_params.output_shift);
+    data->arithmetic_params.quantized_activation_min =
+        std::numeric_limits<int8_t>::min();
+    data->arithmetic_params.quantized_activation_max =
+        std::numeric_limits<int8_t>::max();
+  }
+
+  data->requires_broadcast = !HaveSameShapes(input1, input2);
+
+  micro_context->DeallocateTempTfLiteTensor(input1);
+  micro_context->DeallocateTempTfLiteTensor(input2);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+#if !(defined(HIFI4) || defined(HIFI5))
+inline int8_t SquaredDifference(int8_t x, int8_t y,
+                                const ArithmeticParams& params) {
+  const int32_t input1_val = params.input1_offset + x;
+  const int32_t input2_val = params.input2_offset + y;
+  const int32_t shifted_input1_val = input1_val * (1 << params.left_shift);
+  const int32_t shifted_input2_val = input2_val * (1 << params.left_shift);
+  const int32_t scaled_input1_val =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input1_val, params.input1_multiplier, params.input1_shift);
+  const int32_t scaled_input2_val =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input2_val, params.input2_multiplier, params.input2_shift);
+  const int32_t raw_diff = scaled_input1_val - scaled_input2_val;
+
+  // Max of this is 255^2 * (1 << 14), so won't overflow 32 bits.
+  const int32_t squared_raw_diff = raw_diff * raw_diff;
+  const int32_t raw_output =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          squared_raw_diff, params.output_multiplier, params.output_shift) +
+      params.output_offset;
+  const int32_t clamped_output =
+      std::min(params.quantized_activation_max,
+               std::max(params.quantized_activation_min, raw_output));
+  return static_cast<int8_t>(clamped_output);
+}
+
+template <typename T>
+void EvalQuantizedSquaredDifference(TfLiteContext* context, TfLiteNode* node,
+                                    const OpData* data,
+                                    const TfLiteEvalTensor* input1,
+                                    const TfLiteEvalTensor* input2,
+                                    TfLiteEvalTensor* output) {
+  const auto* op_data = static_cast<const OpData*>(node->user_data);
+  if (data->requires_broadcast) {
+    reference_integer_ops::BroadcastBinaryFunction4DSlow(
+        op_data->arithmetic_params, tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output),
+        reference_integer_ops::CheckArithmeticParams, SquaredDifference);
+  } else {
+    const int flat_size = tflite::micro::GetTensorShape(input1).FlatSize();
+    reference_integer_ops::ElementWise(
+        flat_size, op_data->arithmetic_params,
+        tflite::micro::GetTensorData<int8_t>(input1),
+        tflite::micro::GetTensorData<int8_t>(input2),
+        tflite::micro::GetTensorData<int8_t>(output),
+        reference_integer_ops::CheckArithmeticParams, SquaredDifference);
+  }
+}
+#else // #if !(defined(HIFI4) || defined(HIFI5))
+void EvalQuantizedSquaredDifferenceInt8Hifi(TfLiteContext* context,
+                                            TfLiteNode* node,
+                                            const OpData* data,
+                                            const TfLiteEvalTensor* input1,
+                                            const TfLiteEvalTensor* input2,
+                                            TfLiteEvalTensor* output) {
+  const auto* op_data = static_cast<const OpData*>(node->user_data);
+  const ArithmeticParams& params = op_data->arithmetic_params;
+  int err;
+  const RuntimeShape extended_input1_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+  const RuntimeShape extended_input2_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+  const RuntimeShape extended_output_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+  err = xa_nn_elm_squared_diff_broadcast_4D_asym8sxasym8s_asym8s(
+      tflite::micro::GetTensorData<int8_t>(output),
+      extended_output_shape.DimsData(), params.output_offset,
+      params.output_shift, params.output_multiplier,
+      params.quantized_activation_min,
+      params.quantized_activation_max,
+      tflite::micro::GetTensorData<int8_t>(input1),
+      extended_input1_shape.DimsData(), params.input1_offset,
+      params.input1_shift, params.input1_multiplier,
+      tflite::micro::GetTensorData<int8_t>(input2),
+      extended_input2_shape.DimsData(),
+      params.input2_offset, params.input2_shift,
+      params.input2_multiplier, params.left_shift);
+}
+#endif // #if !(defined(HIFI4) || defined(HIFI5))
+
+template <typename T>
+void EvalSquaredDifference(TfLiteContext* context, TfLiteNode* node,
+                           const OpData* data, const TfLiteEvalTensor* input1,
+                           const TfLiteEvalTensor* input2,
+                           TfLiteEvalTensor* output) {
+  if (data->requires_broadcast) {
+    reference_ops::BroadcastBinaryFunction4DSlow<T, T, T>(
+        tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output), SquaredDifference<T>);
+  } else {
+    reference_ops::BinaryFunction<T, T, T>(
+        tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output), SquaredDifference<T>);
+  }
+}
+
+TfLiteStatus SquaredDifferenceEval(TfLiteContext* context, TfLiteNode* node) {
+  OpData* data = reinterpret_cast<OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  if (output->type == kTfLiteFloat32) {
+    EvalSquaredDifference<float>(context, node, data, input1, input2, output);
+  } else if (output->type == kTfLiteInt32) {
+    EvalSquaredDifference<int32_t>(context, node, data, input1, input2, output);
+  } else if (output->type == kTfLiteInt8) {
+#if defined(HIFI4) || defined(HIFI5)
+    EvalQuantizedSquaredDifferenceInt8Hifi(context, node, data, input1, input2,
+                                           output);
+#else
+    EvalQuantizedSquaredDifference<int8_t>(context, node, data, input1, input2,
+                                           output);
+#endif
+  } else {
+    MicroPrintf(
+        "SquaredDifference only supports FLOAT32, INT32 and INT8 now, got %d.",
+        output->type);
+    return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+}  // namespace
+
+TfLiteRegistration Register_SQUARED_DIFFERENCE() {
+  return tflite::micro::RegisterOp(
+      SquaredDifferenceInit, SquaredDifferencePrepare, SquaredDifferenceEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
@@ -146,12 +146,12 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return CheckOutputSize(context, &op_context);
 }
 
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
-void StridedSlice_int16_hifi4opt(const tflite::StridedSliceParams& op_params,
-                                 const RuntimeShape& unextended_input_shape,
-                                 const int16_t* input_data,
-                                 const RuntimeShape& unextended_output_shape,
-                                 int16_t* output_data) {
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
+void StridedSlice_int16_hifi(const tflite::StridedSliceParams& op_params,
+                             const RuntimeShape& unextended_input_shape,
+                             const int16_t* input_data,
+                             const RuntimeShape& unextended_output_shape,
+                             int16_t* output_data) {
   using ::tflite::strided_slice::StartForAxis;
   using ::tflite::strided_slice::StopForAxis;
 
@@ -190,7 +190,7 @@ void StridedSlice_int16_hifi4opt(const tflite::StridedSliceParams& op_params,
       input_shape.Dims(1), input_shape.Dims(2), input_shape.Dims(3),
       input_shape.Dims(4));
 }
-#endif  // HIFI4_INTERNAL || defined(HIFI4)
+#endif  // HIFI4_INTERNAL || defined(HIFI4) || defined(HIFI5)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
@@ -217,8 +217,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorData<int8_t>(output));
       break;
     case kTfLiteInt16:
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
-      StridedSlice_int16_hifi4opt(
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
+      StridedSlice_int16_hifi(
           op_params, tflite::micro::GetTensorShape(input),
           tflite::micro::GetTensorData<int16_t>(input),
           tflite::micro::GetTensorShape(output),
@@ -229,7 +229,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int16_t>(input),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int16_t>(output));
-#endif  // HIFI4_INTERNAL || defined(HIFI4)
+#endif  // HIFI4_INTERNAL || defined(HIFI4) || defined(HIFI5)
       break;
     case kTfLiteInt32:
       reference_ops::StridedSlice(

--- a/tensorflow/lite/micro/kernels/xtensa/sub.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/sub.cc
@@ -81,12 +81,57 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
   op_params.output_shift = data->output_shift;
   SetActivationParams(data->output_activation_min, data->output_activation_max,
                       &op_params);
+#if !(defined(HIFI4) || defined(HIFI5))
   bool need_broadcast = reference_ops::ProcessBroadcastShapes(
       tflite::micro::GetTensorShape(input1),
       tflite::micro::GetTensorShape(input2), &op_params);
+#endif
 
   switch (output->type) {
     case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5)
+      int err;
+      const RuntimeShape extended_input1_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(output));
+      const int* input1_dims = extended_input1_shape.DimsData();
+      const int* input2_dims = extended_input2_shape.DimsData();
+      const int* output_dims = extended_output_shape.DimsData();
+      int b;
+      int inp1_off = 0;
+      int inp2_off = 0;
+      int out_off;
+      out_off = output_dims[1] * output_dims[2] * output_dims[3]
+                    * output_dims[4];
+      if(input1_dims[0] > 1) {
+        inp1_off = input1_dims[1] * input1_dims[2] * input1_dims[3]
+                      * input1_dims[4];
+      }
+      if(input2_dims[0] > 1) {
+        inp2_off = input2_dims[1] * input2_dims[2] * input2_dims[3]
+                      * input2_dims[4];
+      }
+
+      for(b = 0; b < output_dims[0]; b++)
+      {
+        err = xa_nn_elm_sub_broadcast_4D_asym8sxasym8s_asym8s(
+            tflite::micro::GetTensorData<int8_t>(output) + b * out_off,
+            output_dims + 1, op_params.output_offset, op_params.output_shift,
+            op_params.output_multiplier, op_params.quantized_activation_min,
+            op_params.quantized_activation_max,
+            tflite::micro::GetTensorData<int8_t>(input1) + b * inp1_off,
+            input1_dims + 1, op_params.input1_offset, op_params.input1_shift,
+            op_params.input1_multiplier,
+            tflite::micro::GetTensorData<int8_t>(input2),
+            input2_dims + 1, op_params.input2_offset, op_params.input2_shift,
+            op_params.input2_multiplier, op_params.left_shift);
+
+        TF_LITE_ENSURE(context, err == 0);
+      }
+#else // #if defined(HIFI4) || defined(HIFI5)
       if (need_broadcast) {
         tflite::reference_ops::BroadcastQuantSubSlow(
             op_params, tflite::micro::GetTensorShape(input1),
@@ -96,32 +141,6 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int8_t>(output));
       } else {
-#if defined(HIFI4) || defined(HIFI5)
-        int err;
-        const RuntimeShape& input1_shape = tflite::micro::GetTensorShape(input1);
-        const RuntimeShape& input2_shape = tflite::micro::GetTensorShape(input2);
-        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-        const int flat_size = MatchingElementsSize(input1_shape, input2_shape, output_shape);
-
-        err = xa_nn_elm_sub_asym8sxasym8s_asym8s(tflite::micro::GetTensorData<int8_t>(output),
-                                              op_params.output_offset,
-                                              op_params.output_shift,
-                                              op_params.output_multiplier,
-                                              op_params.quantized_activation_min,
-                                              op_params.quantized_activation_max,
-                                              tflite::micro::GetTensorData<int8_t>(input1) ,
-                                              op_params.input1_offset,
-                                              op_params.input1_shift,
-                                              op_params.input1_multiplier,
-                                              tflite::micro::GetTensorData<int8_t>(input2),
-                                              op_params.input2_offset,
-                                              op_params.input2_shift,
-                                              op_params.input2_multiplier,
-                                              op_params.left_shift,
-                                              flat_size);
-
-        TF_LITE_ENSURE(context, err == 0);
-#else
         tflite::reference_ops::Sub(
             op_params, tflite::micro::GetTensorShape(input1),
             tflite::micro::GetTensorData<int8_t>(input1),
@@ -129,77 +148,55 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorData<int8_t>(input2),
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI4) || defined(HIFI5)
       }
+#endif // #if defined(HIFI4) || defined(HIFI5)
       break;
     }
     case kTfLiteInt16: {
+#if defined(HIFI4) || defined(HIFI5)
+      int err;
+      const RuntimeShape extended_input1_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+          RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(output));
+      const int* input1_dims = extended_input1_shape.DimsData();
+      const int* input2_dims = extended_input2_shape.DimsData();
+      const int* output_dims = extended_output_shape.DimsData();
+      int b;
+      int inp1_off = 0;
+      int inp2_off = 0;
+      int out_off;
+      out_off = output_dims[1] * output_dims[2] * output_dims[3]
+                    * output_dims[4];
+      if(input1_dims[0] > 1) {
+        inp1_off = input1_dims[1] * input1_dims[2] * input1_dims[3]
+                      * input1_dims[4];
+      }
+      if(input2_dims[0] > 1) {
+        inp2_off = input2_dims[1] * input2_dims[2] * input2_dims[3]
+                      * input2_dims[4];
+      }
+
+      for(b = 0; b < output_dims[0]; b++)
+      {
+        err = xa_nn_elm_sub_broadcast_4D_asym16sxasym16s_asym16s(
+            tflite::micro::GetTensorData<int16_t>(output) + b * out_off,
+            output_dims + 1, op_params.output_offset, op_params.output_shift,
+            op_params.output_multiplier, op_params.quantized_activation_min,
+            op_params.quantized_activation_max,
+            tflite::micro::GetTensorData<int16_t>(input1) + b * inp1_off,
+            input1_dims + 1, op_params.input1_offset, op_params.input1_shift,
+            op_params.input1_multiplier,
+            tflite::micro::GetTensorData<int16_t>(input2),
+            input2_dims + 1, op_params.input2_offset, op_params.input2_shift,
+            op_params.input2_multiplier, op_params.left_shift);
+
+        TF_LITE_ENSURE(context, err == 0);
+      }
+#else // #if defined(HIFI4) || defined(HIFI5)
       if (need_broadcast) {
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
-        const RuntimeShape extended_output_shape_debug =
-            RuntimeShape::ExtendedShape(5,
-                                        tflite::micro::GetTensorShape(output));
-
-        int outerloop_count = extended_output_shape_debug.Dims(0) *
-                              extended_output_shape_debug.Dims(1) *
-                              extended_output_shape_debug.Dims(2) *
-                              extended_output_shape_debug.Dims(3);
-
-        int innerloop_count = extended_output_shape_debug.Dims(4);
-
-        int input1_shape_dims =
-            tflite::micro::GetTensorShape(input1).DimensionsCount();
-        int input2_shape_dims =
-            tflite::micro::GetTensorShape(input2).DimensionsCount();
-        int output_shape_dims =
-            tflite::micro::GetTensorShape(output).DimensionsCount();
-
-        if ((input2_shape_dims == 1) && (output_shape_dims == 4) &&
-            (input1_shape_dims == output_shape_dims)) {
-          int err;
-
-         (void)outerloop_count;
-         (void)innerloop_count;
-         const RuntimeShape& input1_shape = tflite::micro::GetTensorShape(input1);
-         const RuntimeShape& input2_shape = tflite::micro::GetTensorShape(input2);
-         const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-
-         const int* inp1_shape = reinterpret_cast<const int*>(input1_shape.DimsData());
-         const int* inp2_shape = reinterpret_cast<const int*>(input2_shape.DimsData());
-         const int* op_shape = reinterpret_cast<const int*>(output_shape.DimsData());
-
-         int ii;
-         int inp1shape[4]={1, 1, 1, 1},inp2shape[4]={1, 1, 1, 1}, opshape[4]={1, 1, 1, 1};
-         for(ii=0; ii<input1_shape.DimensionsCount(); ii++){
-           inp1shape[ii] = inp1_shape[ii];
-           inp2shape[ii] = inp2_shape[ii];
-           opshape[ii] = op_shape[ii];
-         }
-
-         err = xa_nn_elm_sub_broadcast_4D_asym16sxasym16s_asym16s(
-             tflite::micro::GetTensorData<int16_t>(output),
-             opshape,
-             op_params.output_offset, op_params.output_shift,
-             op_params.output_multiplier, op_params.quantized_activation_min,
-             op_params.quantized_activation_max,
-             tflite::micro::GetTensorData<int16_t>(input1),
-             inp1shape,
-             op_params.input1_offset, op_params.input1_shift,
-             op_params.input1_multiplier,
-             tflite::micro::GetTensorData<int16_t>(input2),
-             inp2shape,
-             op_params.input2_offset, op_params.input2_shift,
-             op_params.input2_multiplier, op_params.left_shift);
-        } else {
-          tflite::reference_ops::BroadcastQuantSubSlow(
-              op_params, tflite::micro::GetTensorShape(input1),
-              tflite::micro::GetTensorData<int16_t>(input1),
-              tflite::micro::GetTensorShape(input2),
-              tflite::micro::GetTensorData<int16_t>(input2),
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int16_t>(output));
-        }
-#else
         tflite::reference_ops::BroadcastQuantSubSlow(
             op_params, tflite::micro::GetTensorShape(input1),
             tflite::micro::GetTensorData<int16_t>(input1),
@@ -207,7 +204,6 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorData<int16_t>(input2),
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
-#endif  // HIFI4_INTERNAL || defined(HIFI4)
       } else {
         tflite::reference_ops::Sub(
             op_params, tflite::micro::GetTensorShape(input1),
@@ -217,6 +213,7 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
       }
+#endif // #if defined(HIFI4) || defined(HIFI5)
       break;
     }
     default:

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
@@ -51,7 +51,7 @@ TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
                           TfLiteEvalTensor* output);
 #endif  // defined(HIFI4) || defined (HIFI4_INTERNAL) || defined(HIFI5)
 
-#if defined(HIFI4_INTERNAL) || defined(HIFI4)
+#if defined(HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
 TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
                             const TfLiteConvParams& params,
                             const XtensaConvOpData& data,
@@ -59,7 +59,7 @@ TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
                             const TfLiteEvalTensor* filter,
                             const TfLiteEvalTensor* bias,
                             TfLiteEvalTensor* output);
-#endif  // defined (HIFI4_INTERNAL) || defined(HIFI4)
+#endif  // defined (HIFI4_INTERNAL) || defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
 


### PR DESCRIPTION
…ib v2.8.0

- Integrated Mobilebert related kernels:
    1. xa_nn_matXvec_asym8sxasym8s_asym8s (xa_nn_fully_connected_asym8sxasym8s_asym8s)
    2. xa_nn_elm_mul_broadcast_4D_asym8sxasym8s_asym8s
    3. xa_nn_elm_requantize_asym8s_asym8s
    4. xa_nn_matmul_asym8sxasym8s_asym8s
- Integrated SEANet related kernels:
    1. xa_nn_conv2d_std_per_chan_sym8sxsym16s_sym16s
    2. xa_nn_conv2d_pointwise_per_chan_sym8sxsym16s_sym16s
    3. xa_nn_transpose_conv_sym8sxsym16s_sym16s
    4. xa_nn_leaky_relu_asym16s_asym16s
    5. xa_nn_elm_add_broadcast_4D_asym16sxasym16s_asym16s
    6. xa_nn_strided_slice_16_16
    7. xa_nn_elm_sub_broadcast_4D_asym16sxasym16s_asym16s
    8. xa_nn_pad_16_16
- Integrated other kernels:
    1. xa_nn_elm_quantize_f32_asym8s
    2. xa_nn_elm_add_broadcast_4D_asym8sxasym8s_asym8s
    3. xa_nn_elm_sub_broadcast_4D_asym8sxasym8s_asym8s
    4. xa_nn_elm_squared_diff_broadcast_4D_asym8sxasym8s_asym8s