### PR TITLE
Hifi nnlib latest versions

### DIFF
--- a/tensorflow/lite/micro/kernels/testdata/lstm_test_data.cc
+++ b/tensorflow/lite/micro/kernels/testdata/lstm_test_data.cc
@@ -252,10 +252,17 @@ NodeQuantizationParameters Get2X2Int16LstmQuantizationSettings() {
   // state quantization parameters
   quantization_settings.input = {/*scale=*/3.0518044e-5, /*zp=*/0,
                                  /*symmetry=*/false};
+#if !defined(XTENSA)
   quantization_settings.output = {/*scale=*/1.8310826e-5, /*zp=*/-5461,
                                   /*symmetry=*/false};
   quantization_settings.hidden_state = {/*scale=*/1.8310826e-5, /*zp=*/-5461,
                                         /*symmetry=*/false};
+#else
+  quantization_settings.output = {/*scale=*/1.8310826e-5, /*zp=*/0,
+                                  /*symmetry=*/false};
+  quantization_settings.hidden_state = {/*scale=*/1.8310826e-5, /*zp=*/0,
+                                        /*symmetry=*/false};
+#endif
   quantization_settings.cell_state = {/*scale=*/0.00024414062, /*zp=*/0,
                                       /*symmetry=*/true};
 

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
@@ -122,7 +122,7 @@ void TestUnidirectionalLSTMFloat(
 TF_LITE_MICRO_TESTS_BEGIN
 // TODO(b/230666079) enable below tests for xtensa when the xtensa
 // kernel is reconciled with reference kernel
-#if !defined(XTENSA)
+#if 1 //!defined(XTENSA)
 TF_LITE_MICRO_TEST(TestUnidirectionalLSTMFloat) {
   const tflite::testing::LstmEvalCheckData<12, 4, 12> kernel_eval_data =
       tflite::testing::Get2X2LstmEvalCheckData();

--- a/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.h
+++ b/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.h
@@ -1,0 +1,47 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_MICRO_KERNELS_UNIDIRECTIONAL_SEQUENCE_LSTM_H_
+#define TENSORFLOW_LITE_MICRO_KERNELS_UNIDIRECTIONAL_SEQUENCE_LSTM_H_
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace tflite {
+
+// This is the most generic TfLiteRegistration_V1. The actual supported types
+// may still be target dependent. The only requirement is that every
+// implementation (reference or optimized) must define this function.
+// TODO(b/230666079): resolve conflict with xtensa implementation
+TfLiteRegistration_V1 Register_UNIDIRECTIONAL_SEQUENCE_LSTM();
+
+#if defined(CMSIS_NN)
+// Returns a TfLiteRegistration_V1 struct for kernel variant that only supports
+// int8 activations and int8 weights and uses the latency optimized
+// implementations.
+TfLiteRegistration_V1 Register_UNIDIRECTIONAL_SEQUENCE_LSTM_INT8();
+
+#else
+inline TfLiteRegistration_V1 Register_UNIDIRECTIONAL_SEQUENCE_LSTM_INT8() {
+  return Register_UNIDIRECTIONAL_SEQUENCE_LSTM();
+}
+#endif
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_KERNELS_UNIDIRECTIONAL_SEQUENCE_LSTM_H_


### PR DESCRIPTION
HiFi NNLib integration for LSTM int8 and int16 variants. Enabled unidirectional_sequence_lstm test for xtensa builds, change output and hidden_state zero_point to 0 in lstm test data.