### PR TITLE
Integration of NNLib HiFi4 3.1.0 and HiFi5 2.1.0 kernels.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -84,11 +84,11 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
     int dilation_height = params.dilation_height_factor;
     int dilation_width  = params.dilation_width_factor; 
     if(input->type == kTfLiteInt8){
-    required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
-        input_height, input_width, input_depth, filter_height, filter_width,
-        depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
-        output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
-    TF_LITE_ENSURE(context, required_scratch > 0);        
+      required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+      input_height, input_width, input_depth, filter_height, filter_width,
+      depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+      output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
+      TF_LITE_ENSURE(context, required_scratch > 0);        
     }   
   }
   TF_LITE_ENSURE_OK(

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -80,6 +80,17 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
         output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
     TF_LITE_ENSURE(context, required_scratch > 0);
   }
+  else{
+    int dilation_height = params.dilation_height_factor;
+    int dilation_width  = params.dilation_width_factor; 
+    if(input->type == kTfLiteInt8){
+    required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+        input_height, input_width, input_depth, filter_height, filter_width,
+        depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+        output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
+    TF_LITE_ENSURE(context, required_scratch > 0);        
+    }   
+  }
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
                    context, required_scratch, &data->scratch_tensor_index));
@@ -170,21 +181,78 @@ TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
 
     return kTfLiteOk;
   }
+  else{
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int dilated_width = params.dilation_width_factor;
+    const int dilated_height = params.dilation_height_factor;    
+    const int32_t output_activation_min =
+        data.reference_op_data.output_activation_min;
+    const int32_t output_activation_max =
+        data.reference_op_data.output_activation_max;
+    TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
 
-  reference_integer_ops::DepthwiseConvPerChannel(
-      DepthwiseConvParamsQuantized(params, data.reference_op_data),
-      data.reference_op_data.per_channel_output_multiplier,
-      data.reference_op_data.per_channel_output_shift,
-      tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int8_t>(input),
-      tflite::micro::GetTensorShape(filter),
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetTensorData<int32_t>(bias),
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int8_t>(output));
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
 
-  return kTfLiteOk;
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+    const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+    int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    uint8_t* p_scratch = static_cast<uint8_t*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_dilated_conv2d_depthwise_per_chan_sym8sxasym8s(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, dilated_height, dilated_width, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width,
+              -data.reference_op_data.input_zero_point,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              data.reference_op_data.output_zero_point, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+
+    int out_length = batches * output_height * output_width * output_depth;
+    TF_LITE_ENSURE_EQ(context,
+                      xa_nn_vec_activation_min_max_8_8(
+                          output_data, output_data, output_activation_min,
+                          output_activation_max, out_length),
+                      0);
+
+    return kTfLiteOk;     
+  }
 }
 }  // namespace tflite
 #endif  // defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/logistic.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/logistic.cc
@@ -101,13 +101,22 @@ TfLiteStatus LogisticEval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteInt16: {
       switch (output->type) {
-        case kTfLiteInt16:
+        case kTfLiteInt16 : {
+#if defined(HIFI4) || defined(HIFI5)   
+          TF_LITE_ENSURE_EQ(context, xa_nn_vec_sigmoid_sym16s_sym16s(tflite::micro::GetTensorData<int16_t>(output),
+                                tflite::micro::GetTensorData<int16_t>(input),
+                                data->input_multiplier,
+                                data->input_left_shift,
+                                NumElements(input->dims)), 0);      
+#else
           reference_integer_ops::Logistic(
               data->input_multiplier, data->input_left_shift,
               NumElements(input->dims),
               tflite::micro::GetTensorData<int16_t>(input),
               tflite::micro::GetTensorData<int16_t>(output));
-          break;
+#endif       
+          return kTfLiteOk;       
+        } break;
         default:
           MicroPrintf("Input %s, output %s not supported.",
                       TfLiteTypeGetName(input->type),

--- a/tensorflow/lite/micro/kernels/xtensa/logistic_common.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/logistic_common.cc
@@ -1,0 +1,126 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/logistic.h"
+#include "tensorflow/lite/kernels/internal/reference/logistic.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/logistic.h"
+#if defined(USE_HIFI_ACT_TIE)
+#include <xtensa/tie/xt_hifi2.h>
+#endif
+
+namespace tflite {
+const int kLogisticInputTensor = 0;
+const int kLogisticOutputTensor = 0;
+
+TfLiteStatus CalculateArithmeticOpDataLogistic(TfLiteContext* context,
+                                               TfLiteNode* node,
+                                               OpDataLogistic* data) {
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kLogisticInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kLogisticOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  if (input->type == kTfLiteInt8) {
+    TF_LITE_ENSURE_EQ(context, output->params.zero_point,
+                      std::numeric_limits<int8_t>::min());
+
+    static constexpr int kInputIntegerBits = 4;
+    const double input_real_multiplier =
+        static_cast<double>(input->params.scale) *
+        static_cast<double>(1 << (31 - kInputIntegerBits));
+
+    data->input_zero_point = input->params.zero_point;
+
+    const double q = std::frexp(input_real_multiplier, &data->input_left_shift);
+    data->input_multiplier = static_cast<int32_t>(TfLiteRound(q * (1ll << 31)));
+
+    data->input_range_radius =
+        CalculateInputRadius(kInputIntegerBits, data->input_left_shift, 31);
+  }
+
+  if (input->type == kTfLiteInt16) {
+    static constexpr int kInputIntegerBits = 3;
+    static constexpr int kOutputFractionalBits = 15;
+
+    // See comments in TanhPrepare about requiring zero_point==0
+    // and a power-of-two ("POT") scale.
+
+    TF_LITE_ENSURE_EQ(context, input->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
+
+    int input_scale_log2_rounded;
+    bool param_scale_pot =
+        CheckedLog2(input->params.scale, &input_scale_log2_rounded);
+
+    data->input_left_shift =
+        (15 - kInputIntegerBits) + input_scale_log2_rounded;
+    param_scale_pot &= (data->input_left_shift == 0);
+
+    if (param_scale_pot) {
+      data->input_multiplier = 0;
+    } else {
+      // Calculate multiplier to change input scale to 1/(3*4096)
+      // as required by the table lookup.
+      // In this scaling +/-2^17 represents +/-10.7
+#if (defined(USE_HIFI_ACT_TIE) && (defined(AE_SIGMOID16X4) || defined(AE_SIGMOID16X4X2)))
+      double multiplier =
+          static_cast<double>(input->params.scale) * 4096.0;
+#else      
+      double multiplier =
+          static_cast<double>(input->params.scale) * 4096.0 * 3.0;
+#endif
+      data->input_left_shift = 0;
+
+      while (multiplier <= 32767.0 / 2.0 && data->input_left_shift <= 30) {
+        data->input_left_shift++;
+        multiplier = multiplier * 2.0;
+      }
+
+      data->input_multiplier = static_cast<int32_t>(multiplier);
+    }
+
+    int output_scale_log2_rounded;
+    TF_LITE_ENSURE(
+        context, CheckedLog2(output->params.scale, &output_scale_log2_rounded));
+    TF_LITE_ENSURE_EQ(context, output_scale_log2_rounded,
+                      -kOutputFractionalBits);
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+TfLiteStatus LogisticPrepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  OpDataLogistic* data = static_cast<OpDataLogistic*>(node->user_data);
+
+  return CalculateArithmeticOpDataLogistic(context, node, data);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/transpose.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose.cc
@@ -1,0 +1,134 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kPermTensor = 1;
+constexpr int kOutputTensor = 0;
+
+struct TransposeContext {
+  TransposeContext(TfLiteContext* context, TfLiteNode* node) {
+    micro_context = GetMicroContext(context);
+    input = micro_context->AllocateTempInputTensor(node, kInputTensor);
+    perm = micro_context->AllocateTempInputTensor(node, kPermTensor);
+    output = micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  }
+  ~TransposeContext() {
+    micro_context->DeallocateTempTfLiteTensor(input);
+    micro_context->DeallocateTempTfLiteTensor(perm);
+    micro_context->DeallocateTempTfLiteTensor(output);
+  }
+  MicroContext* micro_context;
+  TfLiteTensor* input;
+  TfLiteTensor* perm;
+  TfLiteTensor* output;
+};
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  TransposeContext op_context(context, node);
+
+  // Ensure validity of input tensor.
+  TF_LITE_ENSURE_MSG(context, NumDimensions(op_context.input) <= 5,
+                     "Transpose op only supports 1D-5D input arrays.");
+  TF_LITE_ENSURE_TYPES_EQ(context, op_context.input->type,
+                          op_context.output->type);
+
+  int dims = NumDimensions(op_context.input);
+  const int32_t* perm_data = GetTensorData<int32_t>(op_context.perm);
+
+  // Ensure validity of the permutations tensor as a 1D tensor.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(op_context.perm), 1);
+  TF_LITE_ENSURE_EQ(context, op_context.perm->dims->data[0], dims);
+  for (int idx = 0; idx < dims; ++idx) {
+    TF_LITE_ENSURE_MSG(context, (perm_data[idx] >= 0 && perm_data[idx] < dims),
+                       "Transpose op permutations array is out of bounds.");
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* perm_tensor =
+      tflite::micro::GetEvalInput(context, node, kPermTensor);
+  const int32_t* perm_data = perm_tensor->data.i32;
+  const int size = perm_tensor->dims->data[0];
+  TransposeParams params;
+  params.perm_count = size;
+  for (int i = 0; i < size; ++i) {
+    params.perm[i] = perm_data[i];
+  }
+
+  // Transpose kernel only does rearranging values not numeric evaluations
+  // on each cell. It's safe to implement per size of scalar type and this
+  // trick keeps the total code size in a reasonable range.
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  switch (input->type) {
+    case kTfLiteFloat32:
+      reference_ops::Transpose(params, tflite::micro::GetTensorShape(input),
+                               tflite::micro::GetTensorData<float>(input),
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt8 : {
+#if defined(HIFI4) || defined(HIFI5)
+    xa_nn_transpose_8_8(tflite::micro::GetTensorData<int8_t>(output),
+                        tflite::micro::GetTensorShape(output).DimsData(),
+                        tflite::micro::GetTensorData<int8_t>(input),
+                        tflite::micro::GetTensorShape(input).DimsData(),
+                        params.perm,
+                        tflite::micro::GetTensorShape(output).DimensionsCount(),
+                        tflite::micro::GetTensorShape(input).DimensionsCount());
+#else    
+      reference_ops::Transpose(params, tflite::micro::GetTensorShape(input),
+                               tflite::micro::GetTensorData<int8_t>(input),
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<int8_t>(output));
+#endif   // defined(HIFI4) || defined(HIFI5)    
+      }                        
+      break;
+    default:
+      MicroPrintf(
+          "Type %s is currently not supported by Transpose. "
+          "Only float32 and int8 is supported",
+          TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TfLiteRegistration_V1 Register_TRANSPOSE() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -325,63 +325,63 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       int32_t* scratch_buffer = static_cast<int32_t*>(
           context->GetScratchBuffer(context, data.scratch_buffer_index));
 #if defined(HIFI4) || defined(HIFI5)
-        if(bias->type == kTfLiteInt32){
-          const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
-          const RuntimeShape& filter_shape =
-              tflite::micro::GetTensorShape(filter);
-          const RuntimeShape& output_shape =
-              tflite::micro::GetTensorShape(output);
-          const int stride_width = data.params.stride_width;
-          const int stride_height = data.params.stride_height;
-          const int pad_width = data.params.padding_values.width;
-          const int pad_height = data.params.padding_values.height;
+      if(bias->type == kTfLiteInt32){
+        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+        const RuntimeShape& filter_shape =
+            tflite::micro::GetTensorShape(filter);
+        const RuntimeShape& output_shape =
+            tflite::micro::GetTensorShape(output);
+        const int stride_width = data.params.stride_width;
+        const int stride_height = data.params.stride_height;
+        const int pad_width = data.params.padding_values.width;
+        const int pad_height = data.params.padding_values.height;
 
-          const int batches = MatchingDim(input_shape, 0, output_shape, 0);
-          const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
-          const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+        const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+        const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+        const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
 
-          const int input_height = input_shape.Dims(1);
-          const int input_width = input_shape.Dims(2);
-          const int filter_height = filter_shape.Dims(1);
-          const int filter_width = filter_shape.Dims(2);
-          const int output_height = output_shape.Dims(1);
-          const int output_width = output_shape.Dims(2);
-          const int8_t* input_data =
-              tflite::micro::GetTensorData<int8_t>(input);
-          const int8_t* filter_data =
-              tflite::micro::GetTensorData<int8_t>(filter);
-          const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
-          int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+        const int input_height = input_shape.Dims(1);
+        const int input_width = input_shape.Dims(2);
+        const int filter_height = filter_shape.Dims(1);
+        const int filter_width = filter_shape.Dims(2);
+        const int output_height = output_shape.Dims(1);
+        const int output_width = output_shape.Dims(2);
+        const int8_t* input_data =
+            tflite::micro::GetTensorData<int8_t>(input);
+        const int8_t* filter_data =
+            tflite::micro::GetTensorData<int8_t>(filter);
+        const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+        int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
 
-          const int num_elements = output_shape.FlatSize();
+        const int num_elements = output_shape.FlatSize();
 
-          for (int b = 0; b < batches; b++) {
-            xa_nn_transpose_conv_sym8sxasym8s(
-                &output_data[b * output_height * output_width * output_depth],
-                const_cast<WORD8*>(
-                    &input_data[b * input_height * input_width * input_depth]),
-                const_cast<WORD8*>(filter_data), const_cast<WORD32*>(bias_data),
-                stride_width, stride_height, pad_width, pad_height, input_depth,
-                output_depth, input_height, input_width, filter_height,
-                filter_width, output_height, output_width, num_elements / batches,
-                data.params.input_offset, data.params.output_offset,
-                data.per_channel_output_shift, data.per_channel_output_multiplier,
-                scratch_buffer);
-          }
+        for (int b = 0; b < batches; b++) {
+          xa_nn_transpose_conv_sym8sxasym8s(
+              &output_data[b * output_height * output_width * output_depth],
+              const_cast<WORD8*>(
+                  &input_data[b * input_height * input_width * input_depth]),
+              const_cast<WORD8*>(filter_data), const_cast<WORD32*>(bias_data),
+              stride_width, stride_height, pad_width, pad_height, input_depth,
+              output_depth, input_height, input_width, filter_height,
+              filter_width, output_height, output_width, num_elements / batches,
+              data.params.input_offset, data.params.output_offset,
+              data.per_channel_output_shift, data.per_channel_output_multiplier,
+              scratch_buffer);
         }
-        else{
-          reference_integer_ops::TransposeConv(
-              data.params, data.per_channel_output_multiplier,
-              data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int8_t>(input),
-              tflite::micro::GetTensorShape(filter),
-              tflite::micro::GetTensorData<int8_t>(filter),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetTensorData<int32_t>(bias),
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int8_t>(output),
-              tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);          
-        }
+      }
+      else{
+        reference_integer_ops::TransposeConv(
+            data.params, data.per_channel_output_multiplier,
+            data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<int8_t>(input),
+            tflite::micro::GetTensorShape(filter),
+            tflite::micro::GetTensorData<int8_t>(filter),
+            tflite::micro::GetTensorShape(bias),
+            tflite::micro::GetTensorData<int32_t>(bias),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<int8_t>(output),
+            tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);          
+      }
 #else
       reference_integer_ops::TransposeConv(
           data.params, data.per_channel_output_multiplier,

--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -183,10 +183,31 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Quantized kernels use an int32 scratch buffer.
   if (input->type == kTfLiteInt8) {
     TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
+#if defined(HIFI4) || defined(HIFI5)
+    const int stride_width = params->stride_width;
+    const int stride_height = params->stride_height;
+
+    const int input_height = SizeOfDimension(input, 1);
+    const int input_width = SizeOfDimension(input, 2);
+    const int input_depth = SizeOfDimension(input, 3);
+    const int output_height = height;
+    const int output_width = width;
+    int32_t scratch_buffer_size = 0;
+    scratch_buffer_size = xa_nn_transpose_conv_getsize(input_height,
+                              input_width, input_depth, filter_height,
+                              filter_width, stride_width, stride_height,
+                              output_height, output_width, num_channels,
+                              PREC_SYM8S, PREC_ASYM8S);
+    TFLITE_DCHECK(context->RequestScratchBufferInArena(
+                      context,
+                      scratch_buffer_size,
+                      &(data->scratch_buffer_index)) == kTfLiteOk);
+#else // #if defined(HIFI4) || defined(HIFI5)    
     TFLITE_DCHECK(context->RequestScratchBufferInArena(
                       context,
                       GetTensorShape(output).FlatSize() * sizeof(int32_t),
                       &(data->scratch_buffer_index)) == kTfLiteOk);
+#endif                      
   }
 
   // Quantized 16x8 kernels use an int64 scratch buffer.
@@ -303,6 +324,65 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt8: {
       int32_t* scratch_buffer = static_cast<int32_t*>(
           context->GetScratchBuffer(context, data.scratch_buffer_index));
+#if defined(HIFI4) || defined(HIFI5)
+        if(bias->type == kTfLiteInt32){
+          const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+          const RuntimeShape& filter_shape =
+              tflite::micro::GetTensorShape(filter);
+          const RuntimeShape& output_shape =
+              tflite::micro::GetTensorShape(output);
+          const int stride_width = data.params.stride_width;
+          const int stride_height = data.params.stride_height;
+          const int pad_width = data.params.padding_values.width;
+          const int pad_height = data.params.padding_values.height;
+
+          const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+          const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+          const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+
+          const int input_height = input_shape.Dims(1);
+          const int input_width = input_shape.Dims(2);
+          const int filter_height = filter_shape.Dims(1);
+          const int filter_width = filter_shape.Dims(2);
+          const int output_height = output_shape.Dims(1);
+          const int output_width = output_shape.Dims(2);
+          const int8_t* input_data =
+              tflite::micro::GetTensorData<int8_t>(input);
+          const int8_t* filter_data =
+              tflite::micro::GetTensorData<int8_t>(filter);
+          const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+          int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+
+          const int num_elements = output_shape.FlatSize();
+
+          for (int b = 0; b < batches; b++) {
+            xa_nn_transpose_conv_sym8sxasym8s(
+                &output_data[b * output_height * output_width * output_depth],
+                const_cast<WORD8*>(
+                    &input_data[b * input_height * input_width * input_depth]),
+                const_cast<WORD8*>(filter_data), const_cast<WORD32*>(bias_data),
+                stride_width, stride_height, pad_width, pad_height, input_depth,
+                output_depth, input_height, input_width, filter_height,
+                filter_width, output_height, output_width, num_elements / batches,
+                data.params.input_offset, data.params.output_offset,
+                data.per_channel_output_shift, data.per_channel_output_multiplier,
+                scratch_buffer);
+          }
+        }
+        else{
+          reference_integer_ops::TransposeConv(
+              data.params, data.per_channel_output_multiplier,
+              data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
+              tflite::micro::GetTensorData<int8_t>(input),
+              tflite::micro::GetTensorShape(filter),
+              tflite::micro::GetTensorData<int8_t>(filter),
+              tflite::micro::GetTensorShape(bias),
+              tflite::micro::GetTensorData<int32_t>(bias),
+              tflite::micro::GetTensorShape(output),
+              tflite::micro::GetTensorData<int8_t>(output),
+              tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);          
+        }
+#else
       reference_integer_ops::TransposeConv(
           data.params, data.per_channel_output_multiplier,
           data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
@@ -314,6 +394,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output),
           tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);
+#endif          
       break;
     }
     case kTfLiteInt16: {


### PR DESCRIPTION
Kernels integrated are :

1. dequantize_asym16s
2. quantize_asym16s
3. transpose_int8
4. tanh/sigmoid_sym16s(LUT and TIE based)
5. transpose_conv_sym8sxasym8s
6. dilated_depth_conv_sym8sxasym8s
7. pad_32
8. strided_slice_32
