### PR TITLE
NNLib HiFi4 3.3.0 & HiFi5 2.3.0 Updates

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_reduce.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_reduce.h
@@ -28,6 +28,8 @@ struct XtensaReduceOpData {
   OpDataReduce reference_op_data;
 
 #if defined(HIFI5) || defined(HIFI4)
+  int32_t updated_multiplier;
+  int32_t updated_shift;
   int scratch_tensor_index;
 #endif
 #if defined(VISION_P6)

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -44,13 +44,13 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
 fi
 
 if [[ ${2} == "hifi4" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_05_25_2023.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_09_05_2023.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi4"
-  LIBRARY_MD5="be28b9dd9a4c0866cc1d6a175488c540"
+  LIBRARY_MD5="2a54e056aef73a4fcffde4643998501a"
 elif [[ ${2} == "hifi5" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi5/raw/master/archive/xa_nnlib_hifi5_05_25_2023.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi5/raw/master/archive/xa_nnlib_hifi5_09_05_2023.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi5"
-  LIBRARY_MD5="cd19d79f2ba81ebaa28930fce91a188c"
+  LIBRARY_MD5="1deb55ef200bf5dbedc70b99b02140c0"
 elif [[ ${2} == "vision_p6" ]]; then
   LIBRARY_URL="https://github.com/foss-xtensa/tflmlib_vision/raw/main/archive/xi_tflmlib_vision_p6_22_06_29.zip"
   LIBRARY_DIRNAME="xi_tflmlib_vision_p6"


### PR DESCRIPTION
1. Updating xtensa_downloads.sh to download latest packages.
2. Updating integration layer for reduce kernel to merge the multiplication factor 1/(num elements in axis) in the output_shift & output_multiplier.