### PR TITLE
Adding support for matmul_sym8sxsym16s , maxpool_16 , conv_depth_quant16, broadcasted_prelu & add_f32, sigmoid_f32, min_max_16/f32 in lstm.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -50,8 +50,6 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
       micro_context->AllocateTempInputTensor(node, kConvWeightsTensor);
   TF_LITE_ENSURE(context, filter != nullptr);
 
-  TF_LITE_ENSURE_EQ(context, input->type, kTfLiteInt8);
-
   const RuntimeShape& input_shape = GetTensorShape(input);
   const RuntimeShape& filter_shape = GetTensorShape(filter);
   const RuntimeShape& output_shape = GetTensorShape(output);
@@ -71,14 +69,23 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   const int pad_height = data->reference_op_data.padding.height;
 
   int required_scratch = 0;
-  // Dilation is currently not supported on HiFi 4 NN Library
+
   if ((params.dilation_width_factor == 1) &&
       (params.dilation_height_factor == 1)) {
-    required_scratch = xa_nn_conv2d_depthwise_getsize(
-        input_height, input_width, input_depth, filter_height, filter_width,
-        depth_multiplier, stride_width, stride_height, pad_width, pad_height,
-        output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
-    TF_LITE_ENSURE(context, required_scratch > 0);
+        if(input->type == kTfLiteInt8){           
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
+        TF_LITE_ENSURE(context, required_scratch > 0);
+        }
+        else if(input->type == kTfLiteInt16){
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
+        TF_LITE_ENSURE(context, required_scratch > 0);            
+        }
   }
   else{
     int dilation_height = params.dilation_height_factor;
@@ -101,7 +108,7 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   return kTfLiteOk;
 }
 
-TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
+TfLiteStatus DepthwiseConvEvalInt8Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,
                                    const TfLiteEvalTensor* input,
@@ -254,5 +261,104 @@ TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
     return kTfLiteOk;     
   }
 }
+
+TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output) {
+  // If dilation is not required use the optimized NN Library kernel.
+  // Otherwise call the reference implementation.
+  if ((params.dilation_width_factor == 1) &&
+      (params.dilation_height_factor == 1)) {
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int32_t output_activation_min =
+        data.reference_op_data.output_activation_min;
+    const int32_t output_activation_max =
+        data.reference_op_data.output_activation_max;
+    TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const int16_t* input_data = tflite::micro::GetTensorData<int16_t>(input);
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+    const int64_t* bias_data = tflite::micro::GetTensorData<int64_t>(bias);
+    int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_depthwise_per_chan_sym8sxsym16s(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width,
+              -data.reference_op_data.input_zero_point,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              data.reference_op_data.output_zero_point, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+
+    int out_length = batches * output_height * output_width * output_depth;
+    TF_LITE_ENSURE_EQ(context,
+                      xa_nn_vec_activation_min_max_16_16(
+                          output_data, output_data, output_activation_min,
+                          output_activation_max, out_length),
+                      0);
+
+    return kTfLiteOk;
+  }
+  else{
+    /* Support for dilated depth int16 not available in NN Library*/
+    reference_integer_ops::DepthwiseConvPerChannel(
+        DepthwiseConvParamsQuantized(params, data.reference_op_data),
+        data.reference_op_data.per_channel_output_multiplier,
+        data.reference_op_data.per_channel_output_shift,
+        tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<int16_t>(input),
+        tflite::micro::GetTensorShape(filter),
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(bias),
+        tflite::micro::GetOptionalTensorData<int64_t>(bias),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<int16_t>(output));
+    return kTfLiteOk;
+  }
+}
+
 }  // namespace tflite
 #endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/pooling.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pooling.cc
@@ -109,7 +109,7 @@ TfLiteStatus MaxEval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteInt8: {
 #if defined(HIFI5) || defined(HIFI4)
-      MaxEvalQuantizedHifi(context, node, params, op_data, input, output);
+      MaxEvalQuantizedInt8Hifi(context, node, params, op_data, input, output);
 #elif defined(VISION_P6)
       const auto& op_data =
           *(reinterpret_cast<XtensaOpDataPooling*>(node->user_data));
@@ -121,8 +121,12 @@ TfLiteStatus MaxEval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteInt16: {
+#if defined(HIFI5) || defined(HIFI4)
+      MaxEvalQuantizedInt16Hifi(context, node, params, op_data, input, output);
+#else
       MaxPoolingEvalQuantized<int16_t>(context, node, params, reference_op_data,
                                        input, output);
+#endif                                       
       break;
     }
     default: {

--- a/tensorflow/lite/micro/kernels/xtensa/pooling_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pooling_int16.cc
@@ -73,4 +73,53 @@ TfLiteStatus AverageEvalQuantizedInt16Hifi(TfLiteContext* context,
   return kTfLiteOk;
 }
 
+TfLiteStatus MaxEvalQuantizedInt16Hifi(TfLiteContext* context,
+                                      const TfLiteNode* node,
+                                      const TfLitePoolParams* params,
+                                      const XtensaOpDataPooling* data,
+                                      const TfLiteEvalTensor* input,
+                                      TfLiteEvalTensor* output) {
+  TFLITE_DCHECK(input->type == kTfLiteInt16);
+
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int depth = MatchingDim(input_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  void* p_scratch = static_cast<void*>(
+      context->GetScratchBuffer(context, data->scratch_tensor_index));
+
+  const int16_t* inp_data_ptr = tflite::micro::GetTensorData<int16_t>(input);
+  int16_t* out_data_ptr = tflite::micro::GetTensorData<int16_t>(output);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_maxpool_16(
+            &out_data_ptr[output_height * output_width * depth * batch],
+            const_cast<int16_t*>(
+                &inp_data_ptr[output_height * output_width * depth * batch]),
+            input_height, input_width, depth, params->filter_height,
+            params->filter_width, params->stride_width, params->stride_height,
+            data->reference_op_data.padding.width,
+            data->reference_op_data.padding.height, output_height, output_width,
+            0, 0, p_scratch),
+        0);
+  }
+
+  const int out_length = batches * output_height * output_width * depth;
+  TF_LITE_ENSURE_EQ(
+      context,
+      xa_nn_vec_activation_min_max_16_16(
+          out_data_ptr, out_data_ptr, data->reference_op_data.activation_min,
+          data->reference_op_data.activation_max, out_length),
+      0);
+
+  return kTfLiteOk;
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/prelu_common.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/prelu_common.cc
@@ -1,0 +1,127 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/prelu.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/prelu.h"
+#if defined(HIFI5) || defined(HIFI4) 
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h"
+#endif
+namespace tflite {
+
+TfLiteStatus CalculatePreluParams(const TfLiteTensor* input,
+                                  const TfLiteTensor* alpha,
+                                  TfLiteTensor* output, PreluParams* params) {
+  if (output->type == kTfLiteInt8 || output->type == kTfLiteInt16) {
+    double real_multiplier_1 = static_cast<double>(input->params.scale) /
+                               static_cast<double>(output->params.scale);
+    double real_multiplier_2 = static_cast<double>(input->params.scale) *
+                               static_cast<double>(alpha->params.scale) /
+                               static_cast<double>(output->params.scale);
+    QuantizeMultiplier(real_multiplier_1, &params->output_multiplier_1,
+                       &params->output_shift_1);
+    QuantizeMultiplier(real_multiplier_2, &params->output_multiplier_2,
+                       &params->output_shift_2);
+
+    params->input_offset = -input->params.zero_point;
+    params->alpha_offset = -alpha->params.zero_point;
+    params->output_offset = output->params.zero_point;
+  }
+
+  return kTfLiteOk;
+}
+
+void BroadcastPrelu4DSlowFloat(const RuntimeShape& unextended_input1_shape,
+                               const float* input1_data,
+                               const RuntimeShape& unextended_input2_shape,
+                               const float* input2_data,
+                               const RuntimeShape& unextended_output_shape,
+                               float* output_data) {
+  TFLITE_DCHECK_LE(unextended_input1_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_LE(unextended_input2_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_LE(unextended_output_shape.DimensionsCount(), 4);
+  const RuntimeShape output_shape =
+      RuntimeShape::ExtendedShape(4, unextended_output_shape);
+
+  NdArrayDesc<4> desc1;
+  NdArrayDesc<4> desc2;
+  NdArrayDescsForElementwiseBroadcast(unextended_input1_shape,
+                                      unextended_input2_shape, &desc1, &desc2);
+
+  for (int b = 0; b < output_shape.Dims(0); ++b) {
+    for (int y = 0; y < output_shape.Dims(1); ++y) {
+      for (int x = 0; x < output_shape.Dims(2); ++x) {
+        for (int c = 0; c < output_shape.Dims(3); ++c) {
+          auto out_idx = Offset(output_shape, b, y, x, c);
+          auto in1_idx = SubscriptToIndex(desc1, b, y, x, c);
+          auto in2_idx = SubscriptToIndex(desc2, b, y, x, c);
+          auto in1_val = input1_data[in1_idx];
+          auto in2_val = input2_data[in2_idx];
+          output_data[out_idx] = in1_val >= 0.0f ? in1_val : in1_val * in2_val;
+        }
+      }
+    }
+  }
+}
+
+TfLiteStatus PreluPrepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  PreluParams* params = static_cast<PreluParams*>(node->user_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* alpha = micro_context->AllocateTempInputTensor(node, 1);
+  TF_LITE_ENSURE(context, alpha != nullptr);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+#if defined(HIFI5) || defined(HIFI4)  
+  TfLiteEvalTensor* output_eval = tflite::micro::GetEvalOutput(context, node, 0);
+  const TfLiteEvalTensor* alpha_eval = tflite::micro::GetEvalInput(context, node, 1);
+  const TfLiteEvalTensor* input_eval = tflite::micro::GetEvalInput(context, node, 0);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output_eval);
+  const RuntimeShape& alpha_shape = tflite::micro::GetTensorShape(alpha_eval);
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input_eval);
+  XtensaPreluData* data = static_cast<XtensaPreluData*>(node->user_data);
+  if(!(alpha_shape == output_shape) && input_shape == output_shape){
+    int required_scratch = 1;
+    for(int i=0; i< output_shape.DimensionsCount(); i++){
+      required_scratch *= output_shape.DimsData()[i];
+    }  
+    TF_LITE_ENSURE(context, required_scratch > 0);
+    TF_LITE_ENSURE_OK(
+        context, context->RequestScratchBufferInArena(
+                    context, required_scratch, &data->scratch_tensor_index));   
+  }
+#endif 
+
+  TF_LITE_ENSURE_OK(context,
+                    CalculatePreluParams(input, alpha, output, params));
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(alpha);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -42,7 +42,15 @@ struct XtensaDepthwiseConvOpData {
 #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
-TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
+TfLiteStatus DepthwiseConvEvalInt8Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output);
+
+TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,
                                    const TfLiteEvalTensor* input,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h
@@ -67,11 +67,18 @@ TfLiteStatus AverageEvalQuantizedInt16Hifi(TfLiteContext* context,
                                       TfLiteEvalTensor* output);
 
 TfLiteStatus MaxPrepareHifi(TfLiteContext* context, TfLiteNode* node);
-TfLiteStatus MaxEvalQuantizedHifi(TfLiteContext* context, TfLiteNode* node,
+TfLiteStatus MaxEvalQuantizedInt8Hifi(TfLiteContext* context, TfLiteNode* node,
                                   TfLitePoolParams* params,
                                   const XtensaOpDataPooling* data,
                                   const TfLiteEvalTensor* input,
                                   TfLiteEvalTensor* output);
+
+TfLiteStatus MaxEvalQuantizedInt16Hifi(TfLiteContext* context,
+                                      const TfLiteNode* node,
+                                      const TfLitePoolParams* params,
+                                      const XtensaOpDataPooling* data,
+                                      const TfLiteEvalTensor* input,
+                                      TfLiteEvalTensor* output);                                  
 
 #endif  // defined(HIFI5)
 

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h
@@ -1,0 +1,32 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_
+#define TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/micro/kernels/prelu.h"
+
+#if defined(HIFI5) || defined(HIFI4)
+namespace tflite {
+struct XtensaPreluData {
+  PreluParams reference_op_data;
+  int scratch_tensor_index;
+};
+}  // namespace tflite
+#endif
+#endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_


### PR DESCRIPTION
1. matmul_sym8sxsym16s in fully_connected.cc
2. maxpool_16 in pooling.cc
3. conv2d_depthwise_sym8sxsym16s in depthwise_conv.cc
4. Support for broadcaster prelu in prelu.cc
5. add_f32, sigmoid_f32, min_max_16/f32 in lstm_eval.cc