### PR TITLE
Updating Conv, Depthwise Conv & FC for operator registrations based on specific data-types

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.h
+++ b/tensorflow/lite/micro/kernels/conv.h
@@ -112,6 +112,12 @@ inline TFLMRegistration Register_CONV_2D_INT8() { return Register_CONV_2D(); }
 inline TFLMRegistration Register_CONV_2D_INT16() { return Register_CONV_2D(); }
 #endif  // defined(CMSIS_NN) || defined(XTENSA)
 
+#if defined(XTENSA)
+
+TFLMRegistration Register_CONV_2D_FLOAT32();
+
+#endif
+
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_CONV_H_

--- a/tensorflow/lite/micro/kernels/depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.h
@@ -76,12 +76,12 @@ inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
 #endif
 
 #if defined(XTENSA)
-
 TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32();
+#endif
+
 TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8REF();
 TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16REF();
 TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32REF();
-#endif
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/kernels/depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.h
@@ -54,7 +54,7 @@ TfLiteStatus DepthwiseConvPrepare(TfLiteContext* context, TfLiteNode* node);
 // implementation (reference or optimized) must define this function.
 TFLMRegistration Register_DEPTHWISE_CONV_2D();
 
-#if defined(CMSIS_NN)
+#if defined(CMSIS_NN) || defined(XTENSA)
 // Returns a TFLMRegistration struct for kernel variant that only supports
 // int8 activations and int8 weights and uses the latency optimized
 // implementations.
@@ -73,6 +73,14 @@ inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8() {
 inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
   return Register_DEPTHWISE_CONV_2D();
 }
+#endif
+
+#if defined(XTENSA)
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8REF();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16REF();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32REF();
 #endif
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -183,11 +183,6 @@ void TestDepthwiseConvQuantizedPerChannel(
       output_scale, output_zero_point, conv_params, filter_packed_type);
 }
 
-// Xtensa kernels do not support float activations., and the corresponding tests
-// are disabled. As a result, helper functions that are only needed for float
-// kernel tests also need to be ifdef'd out to avoid build errors due to unused
-// functions.
-#if !defined(XTENSA)
 void TestDepthwiseConvFloat(int* input_dims_data, const float* input_data,
                             int* filter_dims_data, const float* filter_data,
                             int* bias_dims_data, const float* bias_data,
@@ -215,17 +210,13 @@ void TestDepthwiseConvFloat(int* input_dims_data, const float* input_data,
                                conv_params, 1e-5, tensors_size, tensors);
 }
 
-#endif  // !defined(XTENSA)
-
 }  // namespace
 }  // namespace testing
 }  // namespace tflite
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#if !defined(XTENSA)  // TODO(b/170322965): xtensa kernels are less general than
-                      // reference kernels and we ifdef out test cases that are
-                      // currently known to fail.
+
 TF_LITE_MICRO_TEST(SimpleTest) {
   int input_shape[] = {4, 1, 3, 2, 2};
   const float input_values[] = {1, 2, 7, 8, 3, 4, 9, 10, 5, 6, 11, 12};
@@ -253,6 +244,7 @@ TF_LITE_MICRO_TEST(SimpleTest) {
       bias_values, golden, output_shape, &conv_params, output_data);
 }
 
+#if !defined(XTENSA)
 TF_LITE_MICRO_TEST(SimpleTestRelu) {
   int input_shape[] = {4, 1, 3, 2, 2};
   const float input_values[] = {1, 2, 7, 8, 3, 4, 9, 10, 5, 6, 11, 12};

--- a/tensorflow/lite/micro/kernels/fully_connected.h
+++ b/tensorflow/lite/micro/kernels/fully_connected.h
@@ -107,6 +107,12 @@ inline TFLMRegistration Register_FULLY_CONNECTED_INT16() {
 
 #endif
 
+#if defined(XTENSA)
+
+TFLMRegistration Register_FULLY_CONNECTED_FLOAT32();
+
+#endif
+
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_FULLY_CONNECTED_H_

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -68,29 +68,15 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 #if defined(HIFI5) && defined(NNLIB_HIFI5)
           ConvEvalHifiInt4(context, node, params, op_data, input, filter,
                        bias, output);
-#else // defined(HIFI5) && defined(NNLIB_HIFI5)   
+#elif defined(HIFI4)
           TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
               context, op_data.reference_op_data.filter_buffer_index, filter);
-#if defined(HIFI4)
           ConvEvalHifiInt8(context, node, params, op_data, input, &filter_int8,
                            bias, output);
 #else
-          reference_integer_ops::ConvPerChannel(
-              ConvParamsQuantized(params, op_data.reference_op_data),
-              op_data.reference_op_data.per_channel_output_multiplier,
-              op_data.reference_op_data.per_channel_output_shift,
-              tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int8_t>(input),
-              tflite::micro::GetTensorShape(filter),
-              tflite::micro::GetTensorData<int8_t>(&filter_int8),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int32_t>(bias),
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int8_t>(output));
-          return kTfLiteOk;
-#endif // defined(HIFI4)     
-#endif // defined(HIFI5) && defined(NNLIB_HIFI5)   
-          break;
+          return ConvReferenceEvalInt8(context, node);
+#endif        
+          break;  
         } 
         case kTfLiteInt8: {
 #if defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -54,17 +54,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   switch (input->type) {
     case kTfLiteFloat32: {
-      tflite::reference_ops::Conv(
-          ConvParamsFloat(params, op_data.reference_op_data),
-          tflite::micro::GetTensorShape(input),
-          tflite::micro::GetTensorData<float>(input),
-          tflite::micro::GetTensorShape(filter),
-          tflite::micro::GetTensorData<float>(filter),
-          tflite::micro::GetTensorShape(bias),
-          tflite::micro::GetOptionalTensorData<float>(bias),
-          tflite::micro::GetTensorShape(output),
-          tflite::micro::GetTensorData<float>(output),
-          tflite::micro::GetTensorShape(nullptr), nullptr);
+#if HIFI_VFPU
+      ConvEvalHifiFloat32(context, node, params, op_data, input, filter,
+                   bias, output);
+#else    
+      return ConvReferenceEvalFloat32(context, node);
+#endif          
       break;
     }
     case kTfLiteInt8: {

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -54,7 +54,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   switch (input->type) {
     case kTfLiteFloat32: {
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
       ConvEvalHifiFloat32(context, node, params, op_data, input, filter,
                    bias, output);
 #else    

--- a/tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc
@@ -1,0 +1,66 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/conv.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h"
+
+namespace tflite {
+
+TfLiteStatus ConvReferenceEvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+  const auto& params =
+      *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
+  const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));
+
+  tflite::reference_ops::Conv(
+      ConvParamsFloat(params, op_data.reference_op_data),
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<float>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<float>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetOptionalTensorData<float>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<float>(output),
+      tflite::micro::GetTensorShape(nullptr), nullptr);
+
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -124,7 +124,7 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
       }
       TF_LITE_ENSURE(context, required_scratch > 0);
     }
-#if HIFI_VFPU    
+#if defined(INCLUDE_FLOAT_OPT)    
      if ((input->type == kTfLiteFloat32) && (input_depth == filter_depth)) {
         required_scratch = xa_nn_conv2d_std_getsize(
             input_height, input_width, input_depth, filter_height, filter_width, filter_depth, stride_height,
@@ -580,7 +580,7 @@ TfLiteStatus ConvEvalHifiInt4(TfLiteContext* context, TfLiteNode* node,
 }
 #endif // #if defined(HIFI5) && defined(NNLIB_HIFI5)
 
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
 
 TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
                                const TfLiteConvParams& params,

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -57,7 +57,8 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
   inputs_and_bias_ok =
       inputs_and_bias_ok &&
       (input->type == kTfLiteInt8 ||
-      (input->type == kTfLiteInt16 && bias->type == kTfLiteInt64));
+      (input->type == kTfLiteInt16 && bias->type == kTfLiteInt64) || 
+      input->type == kTfLiteFloat32);
 
   if (inputs_and_bias_ok == 0) {
     micro_context->DeallocateTempTfLiteTensor(input);
@@ -123,6 +124,13 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
       }
       TF_LITE_ENSURE(context, required_scratch > 0);
     }
+#if HIFI_VFPU    
+     if ((input->type == kTfLiteFloat32) && (input_depth == filter_depth)) {
+        required_scratch = xa_nn_conv2d_std_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width, filter_depth, stride_height,
+            pad_height, stride_width, pad_width, output_height, output_width, output_channels, PREC_F32, PREC_F32, params->dilation_height_factor, params->dilation_width_factor, 0/*Out data format*/);
+     }
+#endif     
   }
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
@@ -571,5 +579,101 @@ TfLiteStatus ConvEvalHifiInt4(TfLiteContext* context, TfLiteNode* node,
     return kTfLiteOk;
 }
 #endif // #if defined(HIFI5) && defined(NNLIB_HIFI5)
+
+#if HIFI_VFPU
+
+TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
+                               const TfLiteConvParams& params,
+                               const XtensaConvOpData& data,
+                               const TfLiteEvalTensor* input,
+                               const TfLiteEvalTensor* filter,
+                               const TfLiteEvalTensor* bias,
+                               TfLiteEvalTensor* output) {
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int pad_width = data.reference_op_data.padding.width;
+  const int pad_height = data.reference_op_data.padding.height;
+
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int input_depth = input_shape.Dims(3);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_depth = filter_shape.Dims(3);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
+  const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(filter);
+  const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(bias);
+  float32_t* output_data = tflite::micro::GetTensorData<float32_t>(output);
+
+  int output_data_format = 0;
+  int out_length = output_height * output_width * output_depth;
+  if (filter_height == 1 && filter_width == 1) {
+    for (int batch = 0; batch < batches; ++batch) {
+      float32_t* p_out_temp;
+      p_out_temp = &output_data[batch * out_length];
+
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_pointwise_f32(
+              p_out_temp, const_cast<float32_t*>(filter_data),
+              const_cast<float32_t*>(&input_data[batch * input_height *
+                                              input_width * input_depth]),
+              const_cast<float32_t*>(bias_data), input_height, input_width,
+              input_depth, output_depth, output_data_format),
+          0);
+    }
+  } else {
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int batch = 0; batch < batches; ++batch) {
+      float32_t* p_out_temp;
+      p_out_temp = &output_data[batch * out_length];
+
+      {
+        if(filter_depth == input_depth){
+        TF_LITE_ENSURE_EQ(
+            context,
+            xa_nn_conv2d_std_f32(
+                p_out_temp,
+                &input_data[batch * input_height * input_width * input_depth],
+                const_cast<float32_t*>(filter_data),  // filter_data,
+                bias_data, input_height, input_width, input_depth,
+                filter_height, filter_width, output_depth, stride_width,
+                stride_height, pad_width, pad_height, output_height,
+                output_width,output_data_format, static_cast<void*>(p_scratch)),
+            0);
+        }
+        else{
+        TFLITE_DCHECK(node->user_data != nullptr);
+        const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));  
+        tflite::reference_ops::Conv(
+            ConvParamsFloat(params, op_data.reference_op_data),
+            tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<float>(input),
+            tflite::micro::GetTensorShape(filter),
+            tflite::micro::GetTensorData<float>(filter),
+            tflite::micro::GetTensorShape(bias),
+            tflite::micro::GetOptionalTensorData<float>(bias),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<float>(output),
+            tflite::micro::GetTensorShape(nullptr), nullptr);        
+        }
+      }
+    }
+  }
+
+  return kTfLiteOk;
+}
+#endif
+
 }  // namespace tflite
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -639,7 +639,7 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
       p_out_temp = &output_data[batch * out_length];
 
       {
-        if(filter_depth == input_depth){
+        if((filter_depth == input_depth) && ((params.dilation_width_factor == 1) && (params.dilation_height_factor == 1))){
         TF_LITE_ENSURE_EQ(
             context,
             xa_nn_conv2d_std_f32(

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
@@ -75,6 +75,28 @@ TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
 #endif
 }
 
+TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+  const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  return ConvEvalHifiFloat32(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  return ConvReferenceEvalFloat32(context, node);
+#endif
+}
+
 }  // namespace
 
 TFLMRegistration Register_CONV_2D_INT8() {
@@ -84,6 +106,11 @@ TFLMRegistration Register_CONV_2D_INT8() {
 TFLMRegistration Register_CONV_2D_INT16() {
   return tflite::micro::RegisterOp(ConvInitXtensa, ConvPrepareXtensa,
                                    EvalInt16);
+}
+
+TFLMRegistration Register_CONV_2D_FLOAT32() {
+  return tflite::micro::RegisterOp(ConvInitXtensa, ConvPrepareXtensa,
+                                   EvalFloat32);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
@@ -76,7 +76,7 @@ TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
-#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
   const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));
   const auto& params =
       *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -74,24 +74,26 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  TFLITE_DCHECK(node->user_data != nullptr);
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)    
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
-  const auto& op_data =
-      *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
 
   TfLiteEvalTensor* output =
       tflite::micro::GetEvalOutput(context, node, kDepthwiseConvOutputTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kDepthwiseConvBiasTensor)
+          : nullptr;      
+#endif      
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kDepthwiseConvInputTensor);
   const TfLiteEvalTensor* filter =
       tflite::micro::GetEvalInput(context, node, kDepthwiseConvWeightsTensor);
-  const TfLiteEvalTensor* bias =
-      (NumInputs(node) == 3)
-          ? tflite::micro::GetEvalInput(context, node, kDepthwiseConvBiasTensor)
-          : nullptr;
 
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const auto& op_data =
+      *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
   TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
       context, op_data.reference_op_data.filter_buffer_index, filter);
 
@@ -106,18 +108,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           DepthwiseConvEvalVision(context, node, params, op_data, input,
                                   &filter_int8, bias, output);
 #else
-          reference_integer_ops::DepthwiseConvPerChannel(
-              DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
-              op_data.reference_op_data.per_channel_output_multiplier,
-              op_data.reference_op_data.per_channel_output_shift,
-              tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int8_t>(input),
-              tflite::micro::GetTensorShape(filter),
-              tflite::micro::GetTensorData<int8_t>(&filter_int8),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int32_t>(bias),
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int8_t>(output));
+          DepthwiseConvReferenceEvalInt8(context, node);
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
           break;
         }
@@ -135,18 +126,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           DepthwiseConvEvalInt16Hifi(context, node, params, op_data, input,
                                 &filter_int8, bias, output);
 #else          
-          reference_integer_ops::DepthwiseConvPerChannel(
-              DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
-              op_data.reference_op_data.per_channel_output_multiplier,
-              op_data.reference_op_data.per_channel_output_shift,
-              tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int16_t>(input),
-              tflite::micro::GetTensorShape(filter),
-              tflite::micro::GetTensorData<int8_t>(&filter_int8),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int64_t>(bias),
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int16_t>(output));
+          DepthwiseConvReferenceEvalInt16(context, node);
 #endif              
           break;
         }
@@ -163,18 +143,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input,
                                 &filter_int8, bias, output);
 #else       
-      TFLITE_DCHECK(node->builtin_data != nullptr);
-      const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
-      tflite::reference_ops::DepthwiseConv(
-          DepthwiseConvParamsFloat(params, data),
-          tflite::micro::GetTensorShape(input),
-          tflite::micro::GetTensorData<float>(input),
-          tflite::micro::GetTensorShape(filter),
-          tflite::micro::GetTensorData<float>(filter),
-          tflite::micro::GetTensorShape(bias),
-          tflite::micro::GetOptionalTensorData<float>(bias),
-          tflite::micro::GetTensorShape(output),
-          tflite::micro::GetTensorData<float>(output));
+      DepthwiseConvReferenceEvalFloat32(context, node);
 #endif          
       break;      
     }

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -139,7 +139,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteFloat32: {
-#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
       DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input,
                                 &filter_int8, bias, output);
 #else       

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -158,6 +158,26 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       }
       break;
     }
+    case kTfLiteFloat32: {
+#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+      DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input,
+                                &filter_int8, bias, output);
+#else       
+      TFLITE_DCHECK(node->builtin_data != nullptr);
+      const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+      tflite::reference_ops::DepthwiseConv(
+          DepthwiseConvParamsFloat(params, data),
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<float>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetOptionalTensorData<float>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+#endif          
+      break;      
+    }
     default:
       MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),
                   input->type);

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer,
+                     size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  void* data =
+      context->AllocatePersistentBuffer(context, sizeof(XtensaDepthwiseConvOpData));
+  return data;
+}
+
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc
@@ -1,0 +1,70 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+   tflite::reference_ops::DepthwiseConv(
+       DepthwiseConvParamsFloat(params, data),
+       tflite::micro::GetTensorShape(input),
+       tflite::micro::GetTensorData<float>(input),
+       tflite::micro::GetTensorShape(filter),
+       tflite::micro::GetTensorData<float>(filter),
+       tflite::micro::GetTensorShape(bias),
+       tflite::micro::GetOptionalTensorData<float>(bias),
+       tflite::micro::GetTensorShape(output),
+       tflite::micro::GetTensorData<float>(output));
+
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalFloat32);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -86,6 +86,15 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
             output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
         TF_LITE_ENSURE(context, required_scratch > 0);            
         }
+#if HIFI_VFPU
+        else if(input->type == kTfLiteFloat32){
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_F32, 0 /* NHWC */);
+        TF_LITE_ENSURE(context, required_scratch > 0);            
+        }
+#endif       
   }
   else{
     int dilation_height = params.dilation_height_factor;
@@ -96,7 +105,16 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
       depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
       output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
       TF_LITE_ENSURE(context, required_scratch > 0);        
-    }   
+    }  
+#if HIFI_VFPU
+        else if(input->type == kTfLiteFloat32){
+            required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_F32, 0 /* NHWC */);
+            TF_LITE_ENSURE(context, required_scratch > 0);           
+        }
+#endif         
   }
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
@@ -359,6 +377,128 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
     return kTfLiteOk;
   }
 }
+
+#if HIFI_VFPU
+TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output) {
+  // If dilation is not required use the optimized NN Library kernel.
+  // Otherwise call the reference implementation.
+  if ((params.dilation_width_factor == 1) &&
+      (params.dilation_height_factor == 1)) {
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
+    const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(filter);
+    const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(bias);
+    float32_t* output_data = tflite::micro::GetTensorData<float32_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_depthwise_f32(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+    return kTfLiteOk;
+  }
+  else{
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int dilated_width = params.dilation_width_factor;
+    const int dilated_height = params.dilation_height_factor;    
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
+    const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(filter);
+    const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(bias);
+    float32_t* output_data = tflite::micro::GetTensorData<float32_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_dilated_conv2d_depthwise_f32(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, dilated_height, dilated_width, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+    return kTfLiteOk;     
+  }
+}
+#endif
 
 }  // namespace tflite
 #endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -86,7 +86,7 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
             output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
         TF_LITE_ENSURE(context, required_scratch > 0);            
         }
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
         else if(input->type == kTfLiteFloat32){
         required_scratch = xa_nn_conv2d_depthwise_getsize(
             input_height, input_width, input_depth, filter_height, filter_width,
@@ -106,7 +106,7 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
       output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
       TF_LITE_ENSURE(context, required_scratch > 0);        
     }  
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
         else if(input->type == kTfLiteFloat32){
             required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
             input_height, input_width, input_depth, filter_height, filter_width,
@@ -378,7 +378,7 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
   }
 }
 
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
 TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc
@@ -1,0 +1,70 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+   reference_integer_ops::DepthwiseConvPerChannel(
+       DepthwiseConvParamsQuantized(params, data),
+       data.per_channel_output_multiplier, data.per_channel_output_shift,
+       tflite::micro::GetTensorShape(input),
+       tflite::micro::GetTensorData<int16_t>(input),
+       tflite::micro::GetTensorShape(filter),
+       tflite::micro::GetTensorData<int8_t>(filter),
+       tflite::micro::GetTensorShape(bias),
+       tflite::micro::GetOptionalTensorData<int64_t>(bias),
+       tflite::micro::GetTensorShape(output),
+       tflite::micro::GetTensorData<int16_t>(output));
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalInt16);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
@@ -73,7 +73,7 @@ TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
-#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
   const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
@@ -1,0 +1,114 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+namespace {
+
+TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)    
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
+      context, op_data.reference_op_data.filter_buffer_index, filter);
+
+  return DepthwiseConvEvalInt8Hifi(context, node, params, op_data, input, &filter_int8, bias,
+                          output);
+#else
+  return DepthwiseConvReferenceEvalInt8(context, node);
+#endif
+}
+
+TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  return DepthwiseConvEvalInt16Hifi(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  return DepthwiseConvReferenceEvalInt16(context, node);
+#endif
+}
+
+TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  return DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  return DepthwiseConvReferenceEvalFloat32(context, node);
+#endif
+}
+
+}  // namespace
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa, EvalInt8);
+}
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa,
+                                   EvalInt16);
+}
+
+#if HIFI_VFPU
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa,
+                                   EvalFloat32);
+}
+#endif
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
@@ -105,10 +105,9 @@ TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
                                    EvalInt16);
 }
 
-#if HIFI_VFPU
 TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32() {
   return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa,
                                    EvalFloat32);
 }
-#endif
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc
@@ -1,0 +1,83 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const auto& op_data = *(reinterpret_cast<OpDataConv*>(node->user_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+  const int8_t* filter_data;
+  if (filter->type == kTfLiteInt4) {
+    int8_t* unpacked_filter_data = static_cast<int8_t*>(
+        context->GetScratchBuffer(context, op_data.filter_buffer_index));
+    tflite::tensor_utils::UnpackDenseInt4IntoInt8(
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(filter).FlatSize(), unpacked_filter_data);
+    filter_data = unpacked_filter_data;
+  } else {
+    filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+  }
+
+  reference_integer_ops::DepthwiseConvPerChannel(
+      DepthwiseConvParamsQuantized(params, data),
+      data.per_channel_output_multiplier, data.per_channel_output_shift,
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter), filter_data,
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalInt8);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
@@ -32,9 +32,6 @@ namespace tflite {
 namespace {
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  TFLITE_DCHECK(node->builtin_data != nullptr);
-  const auto* params =
-      static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
 
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kFullyConnectedInputTensor);
@@ -53,17 +50,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   // Checks in Prepare ensure input, output and filter types are all the same.
   switch (input->type) {
     case kTfLiteFloat32: {
-      tflite::reference_ops::FullyConnected(
-          FullyConnectedParamsFloat(params->activation),
-          tflite::micro::GetTensorShape(input),
-          tflite::micro::GetTensorData<float>(input),
-          tflite::micro::GetTensorShape(filter),
-          tflite::micro::GetTensorData<float>(filter),
-          tflite::micro::GetTensorShape(bias),
-          tflite::micro::GetOptionalTensorData<float>(bias),
-          tflite::micro::GetTensorShape(output),
-          tflite::micro::GetTensorData<float>(output));
-      break;
+      return XtensaEvalFullyConnectedQuantizedFloat32(
+        context, node, data, input, filter, bias, output);
     }
 
     case kTfLiteInt8: {

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
@@ -33,7 +33,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
     const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
     const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
   
-#if HIFI_VFPU && (defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
   const float32_t* bias_data =
       nullptr != bias ? tflite::micro::GetTensorData<float32_t>(bias) : nullptr;
   const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
@@ -1,0 +1,118 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/fully_connected.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/fully_connected.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h"
+
+namespace tflite {
+
+TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
+    TfLiteContext* context, TfLiteNode* node, const OpDataFullyConnected& data,
+    const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
+    const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
+  
+#if HIFI_VFPU && (defined(HIFI4) || defined(HIFI5))
+  const float32_t* bias_data =
+      nullptr != bias ? tflite::micro::GetTensorData<float32_t>(bias) : nullptr;
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int num_batches =
+      FlatSizeSkipDim(output_shape, output_shape.DimensionsCount() - 1);
+  const int output_depth =
+      output_shape.Dims(output_shape.DimensionsCount() - 1);
+
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const int filter_dim_count = filter_shape.DimensionsCount();
+  const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
+
+  if(num_batches == 1) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_fully_connected_f32(
+              tflite::micro::GetTensorData<float32_t>(output),
+              tflite::micro::GetTensorData<float32_t>(filter),
+              tflite::micro::GetTensorData<float32_t>(input),
+              bias_data, accum_depth, output_depth),
+          0);
+  }
+  else{
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_matmul_f32xf32_f32(
+              tflite::micro::GetTensorData<float32_t>(output),
+              tflite::micro::GetTensorData<float32_t>(filter),
+              tflite::micro::GetTensorData<float32_t>(input),
+              bias_data, output_depth, accum_depth, accum_depth,
+              num_batches, accum_depth, output_depth, 1),
+          0);    
+  }
+
+#else
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto* params =
+      static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
+
+  tflite::reference_ops::FullyConnected(
+      FullyConnectedParamsFloat(params->activation),
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<float>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<float>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetOptionalTensorData<float>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<float>(output));
+#endif  // defined(HIFI4) || defined(HIFI5)
+  return kTfLiteOk;
+}
+
+namespace {
+
+TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const auto& data =
+      *(static_cast<const OpDataFullyConnected*>(node->user_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedBiasTensor);
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kFullyConnectedOutputTensor);
+
+  return XtensaEvalFullyConnectedQuantizedFloat32(context, node, data, input,
+                                               filter, bias, output);
+}
+
+}  // namespace
+
+TFLMRegistration Register_FULLY_CONNECTED_FLOAT32() {
+  return tflite::micro::RegisterOp(XtensaInitFullyConnected,
+                                   XtensaPrepareFullyConnected, EvalFloat32);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
@@ -69,7 +69,7 @@ TfLiteStatus ConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
                                const TfLiteEvalTensor* bias,
                                TfLiteEvalTensor* output);
 
-#if HIFI_VFPU 
+#if defined(INCLUDE_FLOAT_OPT) 
 TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
                                const TfLiteConvParams& params,
                                const XtensaConvOpData& data,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
@@ -68,6 +68,17 @@ TfLiteStatus ConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
                                const TfLiteEvalTensor* filter,
                                const TfLiteEvalTensor* bias,
                                TfLiteEvalTensor* output);
+
+#if HIFI_VFPU 
+TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
+                               const TfLiteConvParams& params,
+                               const XtensaConvOpData& data,
+                               const TfLiteEvalTensor* input,
+                               const TfLiteEvalTensor* filter,
+                               const TfLiteEvalTensor* bias,
+                               TfLiteEvalTensor* output);
+#endif
+
 #endif  // defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
@@ -87,6 +98,8 @@ TfLiteStatus ConvEvalVision(TfLiteContext* context, TfLiteNode* node,
 TfLiteStatus ConvReferenceEvalInt8(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node);
+
+TfLiteStatus ConvReferenceEvalFloat32(TfLiteContext* context, TfLiteNode* node);
 
 void* ConvInitXtensa(TfLiteContext* context, const char* buffer, size_t length);
 TfLiteStatus ConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node);

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -58,7 +58,7 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
                                    const TfLiteEvalTensor* bias,
                                    TfLiteEvalTensor* output);
 
-#if HIFI_VFPU
+#if defined(INCLUDE_FLOAT_OPT)
 TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -58,8 +58,22 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
                                    const TfLiteEvalTensor* bias,
                                    TfLiteEvalTensor* output);
 
+#if HIFI_VFPU
+TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output);
+#endif
+
 TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context,
                                             TfLiteNode* node);
+TfLiteStatus DepthwiseConvReferenceEvalInt16(TfLiteContext* context,
+                                            TfLiteNode* node);
+TfLiteStatus DepthwiseConvReferenceEvalFloat32(TfLiteContext* context,
+                                            TfLiteNode* node);                                                                                        
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
@@ -76,6 +90,9 @@ TfLiteStatus DepthwiseConvEvalVision(TfLiteContext* context, TfLiteNode* node,
                                      TfLiteEvalTensor* output);
 
 #endif  // VISION_P6
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer, size_t length);
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h
@@ -70,6 +70,11 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedInt16(
     const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
     const TfLiteEvalTensor* bias, TfLiteEvalTensor* output);
 
+TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
+    TfLiteContext* context, TfLiteNode* node, const OpDataFullyConnected& data,
+    const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
+    const TfLiteEvalTensor* bias, TfLiteEvalTensor* output);
+
 TfLiteStatus XtensaCalculateOpDataFullyConnected(
     TfLiteContext* context, TfLiteFusedActivation activation,
     TfLiteType data_type, const TfLiteTensor* input, const TfLiteTensor* filter,

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -8,7 +8,6 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc \
-  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -14,6 +14,7 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pad_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -6,7 +6,9 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -4,6 +4,7 @@
 MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/add_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc \
@@ -12,7 +13,11 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc \


### PR DESCRIPTION
Following updates have been made:
1. Integration of F32 precision NNLib kernel for Conv, Depthwise Conv & FC.
2. Support for operator registrations based on specific data-types for Depthwise Conv.
3. Support for Filter Int4 & Input Int8 kernel in EvalInt8 function of Conv. 
4. Fallback to Reference code in case of Int32 bias & int16 input for EvalInt16 function of Conv. 
5. Guarded F32 precision calls under INCLUDE_FLOAT_OPT instead of HIFI_VFPU for Conv, Depthwise Conv & FC integrations.