### PR TITLE
Fixed build failures + support for int16-->f32 kernel in dequantize.cc and svdf file updates to resolve TFLM unit test failures.

### DIFF
--- a/tensorflow/lite/micro/kernels/svdf.h
+++ b/tensorflow/lite/micro/kernels/svdf.h
@@ -82,7 +82,7 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node);
 // implementation (reference or optimized) must define this function.
 TfLiteRegistration_V1 Register_SVDF();
 
-#if defined(HEXAGON) || defined(CMSIS_NN)
+#if defined(HEXAGON) || defined(CMSIS_NN) || defined(XTENSA)
 TfLiteRegistration_V1 Register_SVDF_INT8();
 
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/dequantize.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/dequantize.cc
@@ -44,7 +44,7 @@ TfLiteStatus DequantizeEval(TfLiteContext* context, TfLiteNode* node) {
 
   if (output->type == kTfLiteFloat32) {
     switch (input->type) {
-      case kTfLiteInt8:
+      case kTfLiteInt8 : {
 #if HIFI_VFPU && (defined(HIFI5) || defined(HIFI4))
         int err;
         const int8_t *input_data_ptr;
@@ -67,13 +67,32 @@ TfLiteStatus DequantizeEval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorData<float>(output));
 #endif // HIFI_VFPU && (defined(HIFI5) || defined(HIFI4))
         break;
-      case kTfLiteInt16:
+      }
+      case kTfLiteInt16 : {
+#if HIFI_VFPU && (defined(HIFI5) || defined(HIFI4))
+        int err;
+        const int16_t *input_data_ptr;
+        float *output_data_ptr;
+        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+        const int flat_size = MatchingFlatSize(input_shape, output_shape);
+        input_data_ptr  = tflite::micro::GetTensorData<int16_t>(input);
+        output_data_ptr = tflite::micro::GetTensorData<float>(output);
+        err = xa_nn_elm_dequantize_asym16s_f32(output_data_ptr,
+                                              input_data_ptr,
+                                              data->quantization_params.zero_point,
+                                              data->quantization_params.scale,
+                                              flat_size);
+                                TF_LITE_ENSURE(context, (err==0) );
+#else
         reference_ops::Dequantize(data->quantization_params,
                                   tflite::micro::GetTensorShape(input),
                                   tflite::micro::GetTensorData<int16_t>(input),
                                   tflite::micro::GetTensorShape(output),
                                   tflite::micro::GetTensorData<float>(output));
+#endif                                  
         break;
+      }
       case kTfLiteUInt8:
         reference_ops::Dequantize(data->quantization_params,
                                   tflite::micro::GetTensorShape(input),

--- a/tensorflow/lite/micro/kernels/xtensa/svdf.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/svdf.cc
@@ -33,7 +33,7 @@ limitations under the License.
 namespace tflite {
 namespace {
 
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
 TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
                                  const TfLiteEvalTensor* input_tensor,
@@ -63,8 +63,8 @@ TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
 #if defined(HIFI5)
   memcpy(state_ptr, state_ptr + 1, num_bytes);
 #else
-  xa_nn_memmove_16(state_ptr, state_ptr + 1, num_bytes);
-#endif
+  xa_nn_memmove_16(state_ptr, state_ptr + 1, (num_bytes >> 1));
+#endif  // defined(HIFI5)
 
   // Note: no need to clear the latest activation, matmul is not accumulative.
 
@@ -91,11 +91,13 @@ TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
     const int16_t* vector2_ptr =
         tflite::micro::GetTensorData<int16_t>(activation_state_tensor) +
         b * n_memory * n_filter;
+    // TODO(#1751): account for optional bias tensor
     const int32_t* bias_ptr =
         tflite::micro::GetTensorData<int32_t>(bias_tensor);
     int8_t* output_ptr =
         tflite::micro::GetTensorData<int8_t>(output_tensor) + b * n_unit;
 
+    // TODO(#1751): account for optional bias tensor
     TF_LITE_ENSURE_EQ(
         context,
         xa_nn_dot_prod_16x16_asym8s(
@@ -106,15 +108,15 @@ TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
   }
   return kTfLiteOk;
 }
-#endif  // defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context != nullptr);
   return context->AllocatePersistentBuffer(context, sizeof(OpDataSvdf));
 }
 
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
+TfLiteStatus PrepareInt8(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFIMINI) || defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto* params = static_cast<const TfLiteSVDFParams*>(node->builtin_data);
 
@@ -154,12 +156,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, num_filters % rank, 0);
   const int num_units = num_filters / rank;
   const int memory_size = weights_time->dims->data[1];
-
-  if (input->type != kTfLiteInt8) {
-    MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),
-                input->type);
-    return kTfLiteError;
-  }
 
   // Validate Input Tensor:
   TF_LITE_ENSURE(context, input->type == kTfLiteInt8);
@@ -210,6 +206,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
       static_cast<double>(activation_state->params.scale *
                           weights_time->params.scale / output->params.scale);
 
+  // TODO(#1751): account for optional bias tensor
   TF_LITE_ENSURE_NEAR(context, static_cast<double>(bias->params.scale),
                       static_cast<double>(activation_state->params.scale *
                                           weights_time->params.scale),
@@ -228,7 +225,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                      &(data->effective_scale_1_b));
   QuantizeMultiplier(effective_scale_2, &(data->effective_scale_2_a),
                      &(data->effective_scale_2_b));
-#endif
+#endif  // defined(HIFIMINI)
 
   data->input_zero_point = input->params.zero_point;
   data->output_zero_point = output->params.zero_point;
@@ -255,10 +252,37 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 #else
   return PrepareSvdf(context, node);
-#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI3) || defined(HIFI4) ||
+        // defined(HIFI5)
 }
 
-TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFIMINI) || defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kSvdfInputTensor);
+  TfLiteTensor* weights_time =
+      micro_context->AllocateTempInputTensor(node, kSvdfWeightsTimeTensor);
+
+  TfLiteStatus status;
+  if (input->type == kTfLiteInt8 && weights_time->type == kTfLiteInt16) {
+    status = PrepareInt8(context, node);
+  } else {
+    status = PrepareSvdf(context, node);
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(weights_time);
+
+  return status;
+#else
+  return PrepareSvdf(context, node);
+#endif  // defined(HIFIMINI) || defined(HIFI3) || defined(HIFI4) ||
+        // defined(HIFI5)
+}
+
+TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
   auto* params = static_cast<TfLiteSVDFParams*>(node->builtin_data);
 
   const TfLiteEvalTensor* input =
@@ -267,6 +291,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsFeatureTensor);
   const TfLiteEvalTensor* weights_time =
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsTimeTensor);
+  // TODO(#1751): account for optional bias tensor
   const TfLiteEvalTensor* bias =
       (NumInputs(node) == 5)
           ? tflite::micro::GetEvalInput(context, node, kSvdfBiasTensor)
@@ -283,56 +308,87 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   return EvalIntegerSvdfHifimini(context, node, input, weights_feature,
                                  weights_time, bias, params, activation_state,
                                  output, data);
-#elif defined(HIFI4) || defined(HIFI5)
+#elif defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
   return EvalIntegerSvdfHifi(context, node, input, weights_feature,
                              weights_time, bias, params, activation_state,
                              output, data);
 #else
+  EvalInt16SvdfReference(context, node, input, weights_feature, weights_time,
+                         bias, params, activation_state, output, data);
+  return kTfLiteOk;
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  auto* params = static_cast<TfLiteSVDFParams*>(node->builtin_data);
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kSvdfInputTensor);
+  const TfLiteEvalTensor* weights_feature =
+      tflite::micro::GetEvalInput(context, node, kSvdfWeightsFeatureTensor);
+  const TfLiteEvalTensor* weights_time =
+      tflite::micro::GetEvalInput(context, node, kSvdfWeightsTimeTensor);
+  // TODO(#1751): account for optional bias tensor
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 5)
+          ? tflite::micro::GetEvalInput(context, node, kSvdfBiasTensor)
+          : nullptr;
+  TfLiteEvalTensor* activation_state = tflite::micro::GetMutableEvalInput(
+      context, node, kSvdfInputActivationStateTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kSvdfOutputTensor);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpDataSvdf& data = *(static_cast<const OpDataSvdf*>(node->user_data));
+
   switch (weights_feature->type) {
     case kTfLiteFloat32: {
       EvalFloatSvdfReference(
           context, node, input, weights_feature, weights_time, bias, params,
           data.scratch_tensor_index, activation_state, output);
-      return kTfLiteOk;
       break;
     }
 
     case kTfLiteInt8: {
       switch (weights_time->type) {
         case kTfLiteInt16: {
-          EvalInt16SvdfReference(context, node, input, weights_feature,
-                                 weights_time, bias, params, activation_state,
-                                 output, data);
-          return kTfLiteOk;
-          break;
+          return EvalInt8(context, node);
         }
+
         case kTfLiteInt8: {
           EvalInt8SvdfReference(context, node, input, weights_feature,
                                 weights_time, bias, params, activation_state,
                                 output, data);
-          return kTfLiteOk;
           break;
         }
-        default:
+
+        default: {
           MicroPrintf("Type %s not currently supported.",
                       TfLiteTypeGetName(weights_time->type));
           return kTfLiteError;
+        }
       }
+      break;
     }
 
-    default:
+    default: {
       MicroPrintf("Type %s not currently supported.",
                   TfLiteTypeGetName(weights_feature->type));
       return kTfLiteError;
+    }
   }
+
   return kTfLiteOk;
-#endif  // defined(HIFI4) || defined(HIFI5)
 }
 
 }  // namespace
 
 TfLiteRegistration_V1 Register_SVDF() {
   return tflite::micro::RegisterOp(Init, Prepare, Eval);
+}
+
+TfLiteRegistration_V1 Register_SVDF_INT8() {
+  return tflite::micro::RegisterOp(Init, PrepareInt8, EvalInt8);
 }
 
 }  // namespace tflite


### PR DESCRIPTION
1. Fixed build failures and added support for int16 --> f32 kernel in dequantize.cc
2. Resolved TFLM test case failures for svdf kernel. Imported files from earlier commit 2f1758581fe8bd46de6b1844d6bf49cf72b5d7bf which were imported from nne_dev branch.