### PR TITLE
Updates to use HiFi5 v3.0.0 & HiFi4 v4.0.0 NNLib Releases.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,31 +32,6 @@ limitations under the License.
 namespace tflite {
 namespace {
 
-void* Init(TfLiteContext* context, const char* buffer, size_t length) {
-  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-  void* data =
-      context->AllocatePersistentBuffer(context, sizeof(XtensaConvOpData));
-#if defined(VISION_P6)
-  if (InitXtensaContext()) {
-    return nullptr;
-  }
-#endif  // defined(VISION_P6)
-
-  return data;
-}
-
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-  TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
-
-#if defined(HIFI4) || defined(HIFI5)
-  TF_LITE_ENSURE_OK(context, ConvPrepareHifi(context, node));
-#endif
-#if defined(VISION_P6)
-  TF_LITE_ENSURE_OK(context, ConvPrepareVision(context, node));
-#endif  // VISION_P6
-  return kTfLiteOk;
-}
-
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
   TFLITE_DCHECK(node->builtin_data != nullptr);
@@ -77,19 +52,33 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
           : nullptr;
 
-  TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
-      context, op_data.reference_op_data.filter_buffer_index, filter);
-
   switch (input->type) {
+    case kTfLiteFloat32: {
+      tflite::reference_ops::Conv(
+          ConvParamsFloat(params, op_data.reference_op_data),
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<float>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetOptionalTensorData<float>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output),
+          tflite::micro::GetTensorShape(nullptr), nullptr);
+      break;
+    }
     case kTfLiteInt8: {
-      switch (filter_int8.type) {
-        case kTfLiteInt8: {
-#if defined(HIFI4) || defined(HIFI5)
-          ConvEvalHifi(context, node, params, op_data, input, &filter_int8,
+      switch (filter->type) {
+        case kTfLiteInt4: {
+#if defined(HIFI5) && defined(NNLIB_HIFI5)
+          ConvEvalHifiInt4(context, node, params, op_data, input, filter,
                        bias, output);
-#elif defined(VISION_P6)
-          return ConvEvalVision(context, node, params, op_data, input,
-                                &filter_int8, bias, output);
+#else // defined(HIFI5) && defined(NNLIB_HIFI5)   
+          TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
+              context, op_data.reference_op_data.filter_buffer_index, filter);
+#if defined(HIFI4)
+          ConvEvalHifiInt8(context, node, params, op_data, input, &filter_int8,
+                           bias, output);
 #else
           reference_integer_ops::ConvPerChannel(
               ConvParamsQuantized(params, op_data.reference_op_data),
@@ -104,28 +93,49 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
               tflite::micro::GetTensorShape(output),
               tflite::micro::GetTensorData<int8_t>(output));
           return kTfLiteOk;
+#endif // defined(HIFI4)     
+#endif // defined(HIFI5) && defined(NNLIB_HIFI5)   
+          break;
+        } 
+        case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5)
+          ConvEvalHifiInt8(context, node, params, op_data, input, filter,
+                           bias, output);
+#elif defined(VISION_P6)
+          // At this time the optimized implementation is failing the unit tests in
+          // ways that are not entirely clear why. For now, we have identified some
+          // of the problem cases and are manually inserting a reference fallback.
+          // See http://b/270720625 for more details.
+          if (op_data.is_per_channel_quantized ||
+              input->dims->data[1] != input->dims->data[2]) {
+            return ConvReferenceEvalInt8(context, node);
+          } else {
+            return ConvEvalVision(context, node, params, op_data, input, filter,
+                                  bias, output);
+          }
+#else
+          return ConvReferenceEvalInt8(context, node);
 #endif
           break;
         }
-
         default:
-          MicroPrintf("Filter type %s (%d) not supported.",
-                      TfLiteTypeGetName(filter->type), filter->type);
+          MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(filter->type),
+                      filter->type);
           return kTfLiteError;
       }
-      return kTfLiteOk;
+      break;
     }
     case kTfLiteInt16: {
-#if defined(HIFI4) || defined(HIFI5)
-      if (bias->type == kTfLiteInt64) {
-        ConvEvalHifi16(context, node, params, op_data, input, filter, bias,
-                       output);
-      }
-      else if (bias->type == kTfLiteInt32) {
-#else  // defined(HIFI4) || defined(HIFI5)
-      if (bias->type == kTfLiteInt64 || bias->type == kTfLiteInt32) {
-#endif  // defined(HIFI4) || defined(HIFI5)
+      if (bias == nullptr || bias->type == kTfLiteInt32) {
         return ConvReferenceEvalInt16(context, node);
+      }
+      else if (bias->type == kTfLiteInt64) {
+#if defined(HIFI4) || defined(HIFI5)
+        ConvEvalHifiInt16(context, node, params, op_data, input, filter, bias,
+                          output);
+#else  // defined(HIFI4) || defined(HIFI5)
+        return ConvReferenceEvalInt16(context, node);
+#endif  // defined(HIFI4) || defined(HIFI5)
       }
       else {
         MicroPrintf("Bias type %s (%d) not supported.",
@@ -139,12 +149,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                   input->type);
       return kTfLiteError;
   }
+
   return kTfLiteOk;
 }
+
 }  // namespace
 
 TfLiteRegistration_V1 Register_CONV_2D() {
-  return tflite::micro::RegisterOp(Init, Prepare, Eval);
+  return tflite::micro::RegisterOp(ConvInitXtensa, ConvPrepareXtensa, Eval);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc
@@ -1,0 +1,64 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h"
+
+namespace tflite {
+
+void* ConvInitXtensa(TfLiteContext* context, const char* buffer,
+                     size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  void* data =
+      context->AllocatePersistentBuffer(context, sizeof(XtensaConvOpData));
+#if defined(VISION_P6)
+  if (InitXtensaContext()) {
+    return nullptr;
+  }
+#endif  // defined(VISION_P6)
+
+  return data;
+}
+
+TfLiteStatus ConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
+
+#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI5) && defined(NNLIB_HIFI5)
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);      
+  if(input->type == kTfLiteInt8 && filter->type == kTfLiteInt4)
+    TF_LITE_ENSURE_OK(context, ConvPrepareHifiInt4(context, node));
+  else
+#endif // defined(HIFI5) && defined(NNLIB_HIFI5)  
+    TF_LITE_ENSURE_OK(context, ConvPrepareHifi(context, node));
+#endif
+#if defined(VISION_P6)
+  TF_LITE_ENSURE_OK(context, ConvPrepareVision(context, node));
+#endif  // defined(VISION_P6)
+
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,24 +13,132 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
 #include <cstdint>
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/common.h"
-#include "tensorflow/lite/kernels/internal/reference/integer_ops/conv.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/reference/conv.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/conv.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/conv.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
 
 namespace tflite {
 
 TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
+  XtensaConvOpData* data = static_cast<XtensaConvOpData*>(node->user_data);
+  const auto params = static_cast<const TfLiteConvParams*>(node->builtin_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  // Calculate scratch memory requirements and request scratch buffer
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kConvOutputTensor);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kConvInputTensor);
+  TfLiteTensor* filter =
+      micro_context->AllocateTempInputTensor(node, kConvWeightsTensor);
+  TfLiteTensor* bias =
+      micro_context->AllocateTempInputTensor(node, kConvBiasTensor);
+
+  const RuntimeShape& input_shape = GetTensorShape(input);
+  const RuntimeShape& filter_shape = GetTensorShape(filter);
+  const RuntimeShape& output_shape = GetTensorShape(output);
+
+  bool inputs_and_bias_ok = bias != nullptr;
+  inputs_and_bias_ok =
+      inputs_and_bias_ok &&
+      (input->type == kTfLiteInt8 ||
+      (input->type == kTfLiteInt16 && bias->type == kTfLiteInt64));
+
+  if (inputs_and_bias_ok == 0) {
+    micro_context->DeallocateTempTfLiteTensor(input);
+    micro_context->DeallocateTempTfLiteTensor(filter);
+    micro_context->DeallocateTempTfLiteTensor(output);
+    if (bias != nullptr) {
+      micro_context->DeallocateTempTfLiteTensor(bias);
+    }
+    return kTfLiteOk;
+  }
+
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int input_depth = input_shape.Dims(3);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_depth = filter_shape.Dims(3);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  const int output_channels = output_shape.Dims(3);
+  const int stride_height = params->stride_height;
+  const int stride_width = params->stride_width;
+  const int pad_height = data->reference_op_data.padding.height;
+  const int pad_width = data->reference_op_data.padding.width;
+
+  int required_scratch = 0;
+  // Dilation is currently not supported for kTfLiteInt16 datatype.
+  if( ((params->dilation_height_factor > 1) || (params->dilation_width_factor > 1)) && input->type == kTfLiteInt8 && (input_depth == filter_depth)) {
+    // For HiFi5, with nnlib-hifi5 versions 1.7.0 onwards and for HiFi4 with nnlib-hifi4 versions 2.5.0 onwards, 
+    // we use the below dilated_conv2d_std getsize() API. For the earlier versions, "output_channels" argument is not needed.
+#if defined(HIFI5) || defined(HIFI4)
+    required_scratch = xa_nn_dilated_conv2d_std_getsize(
+        input_height, input_depth, filter_height, filter_width, stride_height,
+        pad_height, output_height, output_channels, PREC_ASYM8S, params->dilation_height_factor);
+#endif // defined(HIFI5) || defined(HIFI4)
+    TF_LITE_ENSURE(context, required_scratch > 0);
+  }
+  else if ((params->dilation_width_factor == 1) &&
+      (params->dilation_height_factor == 1)) {
+    if (input->type == kTfLiteInt8) {
+      if(input_depth == filter_depth){
+        required_scratch = xa_nn_conv2d_std_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width, filter_depth, stride_height,
+            pad_height, stride_width, pad_width, output_height, output_width, output_channels, PREC_ASYM8S, PREC_SYM8S, params->dilation_height_factor, params->dilation_width_factor, 0/*Out data format*/);
+      }
+      else{
+        required_scratch = xa_nn_conv2d_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width, filter_depth, params->dilation_height_factor, params->dilation_width_factor, stride_height,
+            pad_height, stride_width, pad_width, output_height, output_width, output_channels, PREC_ASYM8S, PREC_SYM8S, 0/*Out data format*/);        
+      }
+      TF_LITE_ENSURE(context, required_scratch > 0);
+    }
+    if (input->type == kTfLiteInt16) {
+      if(input_depth == filter_depth){
+        required_scratch = xa_nn_conv2d_std_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width, filter_depth, stride_height,
+            pad_height, stride_width, pad_width, output_height, output_width, output_channels, PREC_SYM16S, PREC_SYM8S, params->dilation_height_factor, params->dilation_width_factor, 0/*Out data format*/);
+      }
+      else{
+        required_scratch = xa_nn_conv2d_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width, filter_depth, params->dilation_height_factor, params->dilation_width_factor, stride_height,
+            pad_height, stride_width, pad_width, output_height, output_width, output_channels, PREC_SYM16S, PREC_SYM8S, 0/*Out data format*/);               
+      }
+      TF_LITE_ENSURE(context, required_scratch > 0);
+    }
+  }
+  TF_LITE_ENSURE_OK(
+      context, context->RequestScratchBufferInArena(
+                   context, required_scratch, &data->scratch_tensor_index));
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(filter);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  if (bias != nullptr) {
+    micro_context->DeallocateTempTfLiteTensor(bias);
+  }
+  return kTfLiteOk;
+}
+
+#if defined(HIFI5) && defined(NNLIB_HIFI5)
+TfLiteStatus ConvPrepareHifiInt4(TfLiteContext* context, TfLiteNode* node) {
   XtensaConvOpData* data = static_cast<XtensaConvOpData*>(node->user_data);
   const auto params = static_cast<const TfLiteConvParams*>(node->builtin_data);
 
@@ -61,89 +169,72 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
   const int pad_height = data->reference_op_data.padding.height;
 
   int required_scratch = 0;
-  // Group convolution is currently not supported in NNLib
-  if( input_depth == filter_depth) {
-    // Dilation is currently not supported for kTfLiteInt16 datatype.
-    if( ((params->dilation_height_factor > 1) || (params->dilation_width_factor > 1)) && input->type == kTfLiteInt8) {
-      // For HiFi5, with nnlib-hifi5 versions 1.7.0 onwards and for HiFi4 with nnlib-hifi4 versions 2.5.0 onwards, 
-      // we use the below dilated_conv2d_std getsize() API. For the earlier versions, "output_channels" argument is not needed.
-#if defined(HIFI5) || defined(HIFI4)
-      required_scratch = xa_nn_dilated_conv2d_std_getsize(
-          input_height, input_depth, filter_height, filter_width, stride_height,
-          pad_height, output_height, output_channels, PREC_ASYM8S, params->dilation_height_factor);
-#endif // defined(HIFI5) || defined(HIFI4)
-      TF_LITE_ENSURE(context, required_scratch > 0);
-    }
-    else if ((params->dilation_width_factor == 1) &&
-        (params->dilation_height_factor == 1)) {
-      if (input->type == kTfLiteInt8) {
-        required_scratch = xa_nn_conv2d_std_getsize(
-            input_height, input_depth, filter_height, filter_width, stride_height,
+
+  if ((params->dilation_width_factor == 1) &&
+      (params->dilation_height_factor == 1) && 
+      (filter_depth == input_depth)) {
+        required_scratch = xa_nn_conv2d_std_getsize_sym4s(
+            input_height, filter_depth, filter_height, filter_width, stride_height,
             pad_height, output_height, output_channels, PREC_ASYM8S);
         TF_LITE_ENSURE(context, required_scratch > 0);
-      }
-      if (input->type == kTfLiteInt16) {
-        required_scratch = xa_nn_conv2d_std_getsize(
-            input_height, input_depth, filter_height, filter_width, stride_height,
-            pad_height, output_height, output_channels, PREC_SYM16S);
-        TF_LITE_ENSURE(context, required_scratch > 0);
-      }
-    }
-    TF_LITE_ENSURE_OK(
-        context, context->RequestScratchBufferInArena(
-                     context, required_scratch, &data->scratch_tensor_index));
   }
+  else
+  {
+    required_scratch =
+        RuntimeShape(filter->dims->size,
+                    reinterpret_cast<const int32_t*>(filter->dims->data))
+            .FlatSize();      
+  }
+  TF_LITE_ENSURE_OK(
+      context, context->RequestScratchBufferInArena(
+                   context, required_scratch, &data->scratch_tensor_index));
 
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(filter);
   micro_context->DeallocateTempTfLiteTensor(output);
   return kTfLiteOk;
 }
+#endif
 
-TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
-                            const TfLiteConvParams& params,
-                            const XtensaConvOpData& data,
-                            const TfLiteEvalTensor* input,
-                            const TfLiteEvalTensor* filter,
-                            const TfLiteEvalTensor* bias,
-                            TfLiteEvalTensor* output) {
+TfLiteStatus ConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
+                               const TfLiteConvParams& params,
+                               const XtensaConvOpData& data,
+                               const TfLiteEvalTensor* input,
+                               const TfLiteEvalTensor* filter,
+                               const TfLiteEvalTensor* bias,
+                               TfLiteEvalTensor* output) {
   const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
   const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
-  // Dilation and Group convolution is currently not supported on
-  // HiFi 4 NN Library
-  if ((params.dilation_width_factor == 1) &&
-      (params.dilation_height_factor == 1) &&
-      input_shape.Dims(1) >= filter_shape.Dims(1) &&
-      input_shape.Dims(2) >= filter_shape.Dims(2) &&
-      input_shape.Dims(3) == filter_shape.Dims(3)) {
-    const int stride_width = params.stride_width;
-    const int stride_height = params.stride_height;
-    const int pad_width = data.reference_op_data.padding.width;
-    const int pad_height = data.reference_op_data.padding.height;
-    const int32_t output_activation_min =
-        data.reference_op_data.output_activation_min;
-    const int32_t output_activation_max =
-        data.reference_op_data.output_activation_max;
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int pad_width = data.reference_op_data.padding.width;
+  const int pad_height = data.reference_op_data.padding.height;
+  const int32_t output_activation_min =
+      data.reference_op_data.output_activation_min;
+  const int32_t output_activation_max =
+      data.reference_op_data.output_activation_max;
 
-    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
-    const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
-    const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
-    const int input_height = input_shape.Dims(1);
-    const int input_width = input_shape.Dims(2);
-    const int filter_height = filter_shape.Dims(1);
-    const int filter_width = filter_shape.Dims(2);
-    const int output_height = output_shape.Dims(1);
-    const int output_width = output_shape.Dims(2);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_depth = input_shape.Dims(3);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_depth = filter_shape.Dims(3);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
 
-    const int16_t* input_data = tflite::micro::GetTensorData<int16_t>(input);
-    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
-    const int64_t* bias_data = tflite::micro::GetTensorData<int64_t>(bias);
-    int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
+  const int16_t* input_data = tflite::micro::GetTensorData<int16_t>(input);
+  const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+  const int64_t* bias_data = tflite::micro::GetTensorData<int64_t>(bias);
+  int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
 
-    int output_data_format = 0;
-    int out_length = output_height * output_width * output_depth;
-    if (filter_height == 1 && filter_width == 1) {
+  int output_data_format = 0;
+  int out_length = output_height * output_width * output_depth;
+  if(params.dilation_height_factor == 1 && params.dilation_width_factor == 1) {
+    if ((filter_height == 1 && filter_width == 1) && (filter_depth == input_depth)) {
       for (int batch = 0; batch < batches; ++batch) {
         int16_t* p_out_temp;
         p_out_temp = &output_data[batch * out_length];
@@ -176,6 +267,7 @@ TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
         p_out_temp = &output_data[batch * out_length];
 
         {
+          if(filter_depth == input_depth){
           TF_LITE_ENSURE_EQ(
               context,
               xa_nn_conv2d_std_per_chan_sym8sxsym16s(
@@ -190,6 +282,24 @@ TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
                   data.reference_op_data.per_channel_output_shift, 0,
                   output_data_format, static_cast<void*>(p_scratch)),
               0);
+          }
+          else{
+          TF_LITE_ENSURE_EQ(
+              context,
+                xa_nn_conv2d_per_chan_sym8sxsym16s(
+                    p_out_temp,
+                    &input_data[batch * input_height * input_width * input_depth],
+                    const_cast<int8_t*>(filter_data),  // filter_data,
+                    bias_data, input_height, input_width, input_depth,
+                    filter_height, filter_width, filter_depth, params.dilation_height_factor, params.dilation_width_factor, output_depth, stride_width,
+                    stride_height, pad_width, pad_height, output_height,
+                    output_width, 0,
+                    data.reference_op_data.per_channel_output_multiplier,
+                    data.reference_op_data.per_channel_output_shift,
+                    0, output_data_format,
+                    static_cast<void*>(p_scratch)),
+              0);                 
+          }
         }
         TF_LITE_ENSURE_EQ(context,
                           xa_nn_vec_activation_min_max_16_16(
@@ -198,30 +308,189 @@ TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
                           0);
       }
     }
-    return kTfLiteOk;
+  } else {
+    reference_integer_ops::ConvPerChannel(
+        ConvParamsQuantized(params, data.reference_op_data),
+        data.reference_op_data.per_channel_output_multiplier,
+        data.reference_op_data.per_channel_output_shift,
+        tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<int16_t>(input),
+        tflite::micro::GetTensorShape(filter),
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(bias),
+        tflite::micro::GetOptionalTensorData<std::int64_t>(bias),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<int16_t>(output));
   }
-  reference_integer_ops::ConvPerChannel(
-      ConvParamsQuantized(params, data.reference_op_data),
-      data.reference_op_data.per_channel_output_multiplier,
-      data.reference_op_data.per_channel_output_shift,
-      tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int16_t>(input),
-      tflite::micro::GetTensorShape(filter),
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetTensorData<int64_t>(bias),
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int16_t>(output));
+
   return kTfLiteOk;
 }
 
-TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
-                          const TfLiteConvParams& params,
-                          const XtensaConvOpData& data,
-                          const TfLiteEvalTensor* input,
-                          const TfLiteEvalTensor* filter,
-                          const TfLiteEvalTensor* bias,
-                          TfLiteEvalTensor* output) {
+TfLiteStatus ConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
+                              const TfLiteConvParams& params,
+                              const XtensaConvOpData& data,
+                              const TfLiteEvalTensor* input,
+                              const TfLiteEvalTensor* filter,
+                              const TfLiteEvalTensor* bias,
+                              TfLiteEvalTensor* output) {
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const int32_t input_offset = -data.reference_op_data.input_zero_point;
+  const int32_t output_offset = data.reference_op_data.output_zero_point;
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int pad_width = data.reference_op_data.padding.width;
+  const int pad_height = data.reference_op_data.padding.height;
+  const int32_t output_activation_min =
+      data.reference_op_data.output_activation_min;
+  const int32_t output_activation_max =
+      data.reference_op_data.output_activation_max;
+
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_depth = input_shape.Dims(3);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_depth = filter_shape.Dims(3);  
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
+  const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+  const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+  int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+
+  int output_data_format = 0;
+  int out_length = output_height * output_width * output_depth;
+
+  if (filter_height == 1 && filter_width == 1 && stride_width == 1 && stride_height == 1 && 
+      pad_width == 0 && pad_height == 0 && (input_height == output_height) && (input_width == output_width) && (filter_depth == input_depth)) {
+    for (int batch = 0; batch < batches; ++batch) {
+      int8_t* p_out_temp;
+      p_out_temp = &output_data[batch * out_length];
+
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_pointwise_per_chan_sym8sxasym8s(
+              p_out_temp, const_cast<WORD8*>(filter_data),
+              const_cast<WORD8*>(&input_data[batch * input_height *
+                                             input_width * input_depth]),
+              const_cast<WORD32*>(bias_data), input_height, input_width,
+              input_depth, output_depth, input_offset,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift, output_offset,
+              output_data_format),
+          0);
+
+      TF_LITE_ENSURE_EQ(context,
+                        xa_nn_vec_activation_min_max_8_8(
+                            p_out_temp, p_out_temp, output_activation_min,
+                            output_activation_max, out_length),
+                        0);
+    }
+  } else {
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    if(((params.dilation_width_factor > 1)  || (params.dilation_height_factor > 1)) && (filter_depth != input_depth) )
+    {
+      /*Dilated Group-conv not supported*/
+      reference_integer_ops::ConvPerChannel(
+          ConvParamsQuantized(params, data.reference_op_data),
+          data.reference_op_data.per_channel_output_multiplier,
+          data.reference_op_data.per_channel_output_shift,
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<int8_t>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetOptionalTensorData<int32_t>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+          return kTfLiteOk;
+    }
+
+    for (int batch = 0; batch < batches; ++batch) {
+      int8_t* p_out_temp;
+      p_out_temp = &output_data[batch * out_length];
+
+      if (((params.dilation_width_factor > 1)  ||
+          (params.dilation_height_factor > 1)) && 
+          (filter_depth == input_depth))
+      {
+        TF_LITE_ENSURE_EQ(
+            context,
+            xa_nn_dilated_conv2d_std_per_chan_sym8sxasym8s(p_out_temp,
+              &input_data[batch * input_height * input_width * input_depth],
+              const_cast<int8_t*>(filter_data),  // filter_data,
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, output_depth, stride_width, stride_height, pad_width,
+              pad_height, output_height, output_width, input_offset,
+              data.reference_op_data.per_channel_output_multiplier, data.reference_op_data.per_channel_output_shift,
+              output_offset, output_data_format,
+              static_cast<void*>(p_scratch), params.dilation_height_factor, params.dilation_width_factor),
+            0);
+      }
+      else
+      {
+        if(filter_depth == input_depth){
+          TF_LITE_ENSURE_EQ(
+              context,
+              xa_nn_conv2d_std_per_chan_sym8sxasym8s(
+                  p_out_temp,
+                  &input_data[batch * input_height * input_width * input_depth],
+                  const_cast<int8_t*>(filter_data),
+                  bias_data, input_height, input_width, input_depth,
+                  filter_height, filter_width, output_depth, stride_width,
+                  stride_height, pad_width, pad_height, output_height,
+                  output_width, input_offset,
+                  data.reference_op_data.per_channel_output_multiplier,
+                  data.reference_op_data.per_channel_output_shift,
+                  output_offset, output_data_format,
+                  static_cast<void*>(p_scratch)),
+              0);
+        }
+        else{
+          TF_LITE_ENSURE_EQ(
+            context,
+              xa_nn_conv2d_per_chan_sym8sxasym8s(
+                  p_out_temp,
+                  &input_data[batch * input_height * input_width * input_depth],
+                  const_cast<int8_t*>(filter_data),  // filter_data,
+                  bias_data, input_height, input_width, input_depth,
+                  filter_height, filter_width, filter_depth, params.dilation_height_factor, params.dilation_width_factor, output_depth, stride_width,
+                  stride_height, pad_width, pad_height, output_height,
+                  output_width, input_offset,
+                  data.reference_op_data.per_channel_output_multiplier,
+                  data.reference_op_data.per_channel_output_shift,
+                  output_offset, output_data_format,
+                  static_cast<void*>(p_scratch)),
+              0);              
+        }
+      }
+
+      TF_LITE_ENSURE_EQ(context,
+                        xa_nn_vec_activation_min_max_8_8(
+                            p_out_temp, p_out_temp, output_activation_min,
+                            output_activation_max, out_length),
+                        0);
+    }
+  }
+
+  return kTfLiteOk;
+}
+
+#if defined(HIFI5) && defined(NNLIB_HIFI5)
+TfLiteStatus ConvEvalHifiInt4(TfLiteContext* context, TfLiteNode* node,
+                              const TfLiteConvParams& params,
+                              const XtensaConvOpData& data,
+                              const TfLiteEvalTensor* input,
+                              const TfLiteEvalTensor* filter,
+                              const TfLiteEvalTensor* bias,
+                              TfLiteEvalTensor* output) {
   const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
   const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
 
@@ -256,103 +525,66 @@ TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
   int output_data_format = 0;
   int out_length = output_height * output_width * output_depth;
 
-  // Group convolution is currently not supported in NNLib
-  if (input_depth == filter_depth) {
-    if (filter_height == 1 && filter_width == 1 && stride_width == 1 && stride_height == 1 && 
-        pad_width == 0 && pad_height == 0 && (input_height == output_height) &&
-        (input_width == output_width)) {
-      for (int batch = 0; batch < batches; ++batch) {
-        int8_t* p_out_temp;
-        p_out_temp = &output_data[batch * out_length];
+  if ((params.dilation_width_factor == 1)  &&
+      (params.dilation_height_factor == 1) &&
+      (filter_depth == input_depth))
+  {
+    void* p_scratch = static_cast<void*>(
+      context->GetScratchBuffer(context, data.scratch_tensor_index));
 
-        TF_LITE_ENSURE_EQ(
-            context,
-            xa_nn_conv2d_pointwise_per_chan_sym8sxasym8s(
-                p_out_temp, const_cast<WORD8*>(filter_data),
-                const_cast<WORD8*>(&input_data[batch * input_height *
-                                               input_width * input_depth]),
-                const_cast<WORD32*>(bias_data), input_height, input_width,
-                input_depth, output_depth, input_offset,
-                data.reference_op_data.per_channel_output_multiplier,
-                data.reference_op_data.per_channel_output_shift, output_offset,
-                output_data_format),
-            0);
+    for (int batch = 0; batch < batches; ++batch) {
+      int8_t* p_out_temp;
+      p_out_temp = &output_data[batch * out_length];
 
-        TF_LITE_ENSURE_EQ(context,
-                          xa_nn_vec_activation_min_max_8_8(
-                              p_out_temp, p_out_temp, output_activation_min,
-                              output_activation_max, out_length),
-                          0);
-      }
-    } else {
-      void* p_scratch = static_cast<void*>(
-          context->GetScratchBuffer(context, data.scratch_tensor_index));
 
-      for (int batch = 0; batch < batches; ++batch) {
-        int8_t* p_out_temp;
-        p_out_temp = &output_data[batch * out_length];
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_std_per_chan_sym4sxasym8s(
+            p_out_temp,
+              &input_data[batch * input_height * input_width * input_depth],
+              const_cast<int8_t*>(filter_data),  // filter_data,
+              bias_data, input_height, input_width, input_depth,
+              filter_height, filter_width, output_depth, stride_width,
+              stride_height, pad_width, pad_height, output_height,
+              output_width, input_offset,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              output_offset, output_data_format,
+              static_cast<void*>(p_scratch)),
+          0);
 
-        if ((params.dilation_width_factor > 1)  ||
-            (params.dilation_height_factor > 1))
-        {
-          TF_LITE_ENSURE_EQ(
-              context,
-              xa_nn_dilated_conv2d_std_per_chan_sym8sxasym8s(p_out_temp,
-                &input_data[batch * input_height * input_width * input_depth],
-                const_cast<int8_t*>(filter_data),  // filter_data,
-                bias_data, input_height, input_width, input_depth, filter_height,
-                filter_width, output_depth, stride_width, stride_height, pad_width,
-                pad_height, output_height, output_width, input_offset,
-                data.reference_op_data.per_channel_output_multiplier, data.reference_op_data.per_channel_output_shift,
-                output_offset, output_data_format,
-                static_cast<void*>(p_scratch), params.dilation_height_factor, params.dilation_width_factor),
-              0);
-        }
-        else
-        {
-          TF_LITE_ENSURE_EQ(
-              context,
-              xa_nn_conv2d_std_per_chan_sym8sxasym8s(
-                  p_out_temp,
-                  &input_data[batch * input_height * input_width * input_depth],
-                  const_cast<int8_t*>(filter_data),  // filter_data,
-                  bias_data, input_height, input_width, input_depth,
-                  filter_height, filter_width, output_depth, stride_width,
-                  stride_height, pad_width, pad_height, output_height,
-                  output_width, input_offset,
-                  data.reference_op_data.per_channel_output_multiplier,
-                  data.reference_op_data.per_channel_output_shift,
-                  output_offset, output_data_format,
-                  static_cast<void*>(p_scratch)),
-              0);
-        }
-
-        TF_LITE_ENSURE_EQ(context,
-                          xa_nn_vec_activation_min_max_8_8(
-                              p_out_temp, p_out_temp, output_activation_min,
-                              output_activation_max, out_length),
-                          0);
+      TF_LITE_ENSURE_EQ(context,
+                        xa_nn_vec_activation_min_max_8_8(
+                            p_out_temp, p_out_temp, output_activation_min,
+                            output_activation_max, out_length),
+                      0);            
       }
     }
-    return kTfLiteOk;
-  }
-  else {
-    reference_integer_ops::ConvPerChannel(
-        ConvParamsQuantized(params, data.reference_op_data),
-        data.reference_op_data.per_channel_output_multiplier,
-        data.reference_op_data.per_channel_output_shift,
-        tflite::micro::GetTensorShape(input),
-        tflite::micro::GetTensorData<int8_t>(input),
-        tflite::micro::GetTensorShape(filter),
-        tflite::micro::GetTensorData<int8_t>(filter),
-        tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetOptionalTensorData<int32_t>(bias),
-        tflite::micro::GetTensorShape(output),
-        tflite::micro::GetTensorData<int8_t>(output));
-    return kTfLiteOk;
-  }
+    else
+    {
+      int8_t* unpacked_filter_data = static_cast<int8_t*>(
+          context->GetScratchBuffer(context, data.scratch_tensor_index));
 
+      tflite::tensor_utils::UnpackDenseInt4IntoInt8(
+          tflite::micro::GetTensorData<int8_t>(filter),
+          tflite::micro::GetTensorShape(filter).FlatSize(), unpacked_filter_data);
+      filter_data = unpacked_filter_data;   
+
+      reference_integer_ops::ConvPerChannel(
+          ConvParamsQuantized(params, data.reference_op_data),
+          data.reference_op_data.per_channel_output_multiplier,
+          data.reference_op_data.per_channel_output_shift,
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(filter),
+          filter_data,
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetTensorData<int32_t>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));        
+    }
+    return kTfLiteOk;
 }
-
+#endif // #if defined(HIFI5) && defined(NNLIB_HIFI5)
 }  // namespace tflite
-#endif  // defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
@@ -25,9 +25,9 @@ namespace tflite {
 struct XtensaConvOpData {
   OpDataConv reference_op_data;
 
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
   int scratch_tensor_index;
-#endif  // defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
   int8_t* reorder_coefficient_bias;  // buffers used to keep reordered coeff and
@@ -36,29 +36,38 @@ struct XtensaConvOpData {
   int8_t* per_channel_output_shift_int8;
   uint8_t* p_context;  // persistent lib context for this instance saved here
   uint32_t context_size;
+  bool is_per_channel_quantized;
 #endif  // VISION_P6
 };
 
 #if defined(HIFI4) || defined(HIFI5)
 TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
+#if defined(HIFI5) && defined(NNLIB_HIFI5)
+TfLiteStatus ConvPrepareHifiInt4(TfLiteContext* context, TfLiteNode* node);
 
-TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
-                          const TfLiteConvParams& params,
-                          const XtensaConvOpData& data,
-                          const TfLiteEvalTensor* input,
-                          const TfLiteEvalTensor* filter,
-                          const TfLiteEvalTensor* bias,
-                          TfLiteEvalTensor* output);
-#endif  // defined(HIFI4) || defined(HIFI5)
+TfLiteStatus ConvEvalHifiInt4(TfLiteContext* context, TfLiteNode* node,
+                              const TfLiteConvParams& params,
+                              const XtensaConvOpData& data,
+                              const TfLiteEvalTensor* input,
+                              const TfLiteEvalTensor* filter,
+                              const TfLiteEvalTensor* bias,
+                              TfLiteEvalTensor* output);
+#endif
+TfLiteStatus ConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
+                              const TfLiteConvParams& params,
+                              const XtensaConvOpData& data,
+                              const TfLiteEvalTensor* input,
+                              const TfLiteEvalTensor* filter,
+                              const TfLiteEvalTensor* bias,
+                              TfLiteEvalTensor* output);
 
-#if defined(HIFI4) || defined(HIFI5)
-TfLiteStatus ConvEvalHifi16(TfLiteContext* context, TfLiteNode* node,
-                            const TfLiteConvParams& params,
-                            const XtensaConvOpData& data,
-                            const TfLiteEvalTensor* input,
-                            const TfLiteEvalTensor* filter,
-                            const TfLiteEvalTensor* bias,
-                            TfLiteEvalTensor* output);
+TfLiteStatus ConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
+                               const TfLiteConvParams& params,
+                               const XtensaConvOpData& data,
+                               const TfLiteEvalTensor* input,
+                               const TfLiteEvalTensor* filter,
+                               const TfLiteEvalTensor* bias,
+                               TfLiteEvalTensor* output);
 #endif  // defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
@@ -78,6 +87,9 @@ TfLiteStatus ConvEvalVision(TfLiteContext* context, TfLiteNode* node,
 TfLiteStatus ConvReferenceEvalInt8(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node);
+
+void* ConvInitXtensa(TfLiteContext* context, const char* buffer, size_t length);
+TfLiteStatus ConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
@@ -1,0 +1,848 @@
+diff --git a/algo/common/include/xa_nn_common.h b/algo/common/include/xa_nn_common.h
+index 5a45d27..4fa7215 100644
+--- a/algo/common/include/xa_nn_common.h
++++ b/algo/common/include/xa_nn_common.h
+@@ -64,8 +64,10 @@
+ #define STRINGIZE(A) STRINGIZE_NX(A)    /*  Turn A into a string literal after macro-expanding it. */
+ //#include STRINGIZE(PPCAT(cstub,XTENSA_CORE).h)
+ //#include STRINGIZE(PPCAT(PPCAT(cstub,XTENSA_CORE),c.h))
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include "xtensa/tie/xt_hifi3.h"
+ #include "xtensa/config/core-isa.h"
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ #endif
+ 
+ //-----------------------------------------------------
+@@ -89,6 +91,7 @@
+ #define INV_TBL_BITS 7
+ extern const int32_t tab_invQ30[128];
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #if XCHAL_HAVE_NSA
+   #define NSA(n) XT_NSA(n)
+ #else
+@@ -100,6 +103,7 @@ extern const int32_t tab_invQ30[128];
+     return AE_NSAQ56S(t)-8;
+   }
+ #endif
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ #ifdef COMPILER_XTENSA
+   #define ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+@@ -123,11 +127,13 @@ extern const int32_t tab_invQ30[128];
+ #define return_int64(x) {  union {ae_int64  ai;int64_t   i; } r; r.ai = x;  return r.i; }
+ #endif
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #if  defined (__cplusplus) || defined(COMPILER_XTENSA)
+ 
+ #else
+ #error sorry, C compiler is not supported excluding the XCC
+ #endif
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ 
+ #ifdef COMPILER_MSVC
+diff --git a/algo/common/include/xa_nnlib_common.h b/algo/common/include/xa_nnlib_common.h
+index fcf379a..d66f2a0 100644
+--- a/algo/common/include/xa_nnlib_common.h
++++ b/algo/common/include/xa_nnlib_common.h
+@@ -21,12 +21,16 @@
+ ******************************************************************************/
+ #ifndef __XA_NNLIB_LEGACY_COMPAT_H__
+ #define __XA_NNLIB_LEGACY_COMPAT_H__
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include <xtensa/config/core-isa.h>
+ #include "xtensa/tie/xt_hifi2.h"
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ #include "xa_nnlib_api.h"
+ #include "xa_nnlib_standards.h"
+ #include "xa_nnlib_err_chk.h"
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include "xa_nnlib_hifi_isa_compat.h"
++#endif
+ #include "xa_nn_common.h"
+ #include "xa_nnlib_common_internal.h"
+ #endif /* __XA_NNLIB_LEGACY_COMPAT_H__ */
+@@ -36,4 +40,4 @@
+ #define XA_HAVE_HIFI3_CORE 1
+ #else
+ #define XA_HAVE_HIFI3_CORE 0
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/algo/common/include/xa_nnlib_common_macros.h b/algo/common/include/xa_nnlib_common_macros.h
+index a2d1867..4b3f0c5 100644
+--- a/algo/common/include/xa_nnlib_common_macros.h
++++ b/algo/common/include/xa_nnlib_common_macros.h
+@@ -23,7 +23,9 @@
+ #ifndef __XA_NNLIB_COMMON_MACROS_H__
+ #define __XA_NNLIB_COMMON_MACROS_H__
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include <xtensa/config/core-isa.h>
++#endif
+ #include <stddef.h>
+ #include "xa_nnlib_quant_macros.h"
+ #include "xa_nnlib_common_internal.h"
+@@ -32,6 +34,8 @@
+ #define NULL (void *)0
+ #endif /* NULL */
+ 
++#define MAX(a, b)   (((a) > (b)) ? (a) : (b))
++
+ #if XCHAL_HAVE_HIFI1
+ 
+ #if (XCHAL_HW_VERSION >= 281090)
+diff --git a/algo/kernels/basic/hifi4/xa_nn_reduce_asym8s_asym8s.c b/algo/kernels/basic/hifi4/xa_nn_reduce_asym8s_asym8s.c
+index 47b0956..b400bcb 100644
+--- a/algo/kernels/basic/hifi4/xa_nn_reduce_asym8s_asym8s.c
++++ b/algo/kernels/basic/hifi4/xa_nn_reduce_asym8s_asym8s.c
+@@ -33,17 +33,6 @@
+ 
+ #define BUS_WIDTH_8 7
+ 
+-#define STORE_8X4_FROM_16X4(out_ptr, val){\
+-    int o1, o2, o3, o4;\
+-    o1 = AE_MOVAD16_3(val);\
+-    o2 = AE_MOVAD16_2(val);\
+-    o3 = AE_MOVAD16_1(val);\
+-    o4 = AE_MOVAD16_0(val);\
+-    *out_ptr++ = (WORD8)o1;\
+-    *out_ptr++ = (WORD8)o2;\
+-    *out_ptr++ = (WORD8)o3;\
+-    *out_ptr++ = (WORD8)o4;\
+-}
+ 
+ WORD32 xa_nn_reduce_getsize_nhwc(WORD32 inp_precision
+                                  ,const WORD32 *const p_inp_shape
+@@ -96,6 +85,20 @@ WORD32 xa_nn_reduce_getsize_nhwc(WORD32 inp_precision
+     return 0;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
++
++#define STORE_8X4_FROM_16X4(out_ptr, val){\
++    int o1, o2, o3, o4;\
++    o1 = AE_MOVAD16_3(val);\
++    o2 = AE_MOVAD16_2(val);\
++    o3 = AE_MOVAD16_1(val);\
++    o4 = AE_MOVAD16_0(val);\
++    *out_ptr++ = (WORD8)o1;\
++    *out_ptr++ = (WORD8)o2;\
++    *out_ptr++ = (WORD8)o3;\
++    *out_ptr++ = (WORD8)o4;\
++}
++
+ static void vecmax8_inpx3_aligned(const WORD8 *p_src1, const WORD8* p_src2, const WORD8* p_src3, WORD8 *p_dst, int N){
+     int i = 0;
+ #if XCHAL_HAVE_HIFI1
+@@ -1992,3 +1995,4 @@ WORD32 xa_nn_reduce_mean_4D_asym8s_asym8s(WORD8 * __restrict__ p_out
+ 
+   return 0;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+diff --git a/algo/kernels/cnn/hifi4/xa_nn_circ_buf.c b/algo/kernels/cnn/hifi4/xa_nn_circ_buf.c
+index dace733..7e9856d 100644
+--- a/algo/kernels/cnn/hifi4/xa_nn_circ_buf.c
++++ b/algo/kernels/cnn/hifi4/xa_nn_circ_buf.c
+@@ -46,7 +46,7 @@ int xa_nn_circ_buf_nchw_getsize(
+   }
+ 
+   circ_buf_width = kernel_width + ((output_width - 1) * x_stride);
+-  circ_buf_width = XT_MAX(circ_buf_width, x_padding + input_width);
++  circ_buf_width = MAX(circ_buf_width, x_padding + input_width);
+ 
+   /* Aligned size independent of bytewidth */
+   circ_buf_width = ALIGNED_SIZE(circ_buf_width, 4);
+@@ -388,8 +388,7 @@ int xa_nn_dilated_circ_buf_nhwc_getsize(
+   int size_in_bytes;
+ 
+   circ_buf_height = kernel_height + ((output_height - 1) * y_stride);
+-//  circ_buf_height = XT_MAX(circ_buf_height, y_padding + input_height);
+-  circ_buf_height = XT_MAX(circ_buf_height, (y_padding + input_height + dilation_height - 1)/dilation_height);
++  circ_buf_height = MAX(circ_buf_height, (y_padding + input_height + dilation_height - 1)/dilation_height);
+ 
+   if(bytewidth == 4)
+   {
+diff --git a/algo/kernels/cnn/hifi4/xa_nn_conv2d_depthwise.c b/algo/kernels/cnn/hifi4/xa_nn_conv2d_depthwise.c
+index ac6ab07..04aa355 100644
+--- a/algo/kernels/cnn/hifi4/xa_nn_conv2d_depthwise.c
++++ b/algo/kernels/cnn/hifi4/xa_nn_conv2d_depthwise.c
+@@ -76,7 +76,7 @@ static WORD32 xa_nn_dilated_conv2d_depthwise_nchw_getsize
+     circ_buf_size = ALIGNED_SIZE(circ_buf_size, ALIGNMENT);
+ 
+     circ_buf_width = dilated_kernel_width + ((output_width - 1) * x_stride);
+-    circ_buf_width = XT_MAX(circ_buf_width, x_padding+input_width);
++    circ_buf_width = MAX(circ_buf_width, x_padding+input_width);
+     circ_buf_width = ALIGNED_SIZE(circ_buf_width, 4);
+ 
+     /* Please note for future output_width_for_x_stride_1 calculation for getting output_width_for_x_stride_1
+@@ -107,6 +107,7 @@ static WORD32 xa_nn_dilated_conv2d_depthwise_nchw_getsize
+     }
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ static VOID xa_nn_conv2d_depthwise_nchw_init
+ (pVOID p_scratch
+  ,WORD32 input_width
+@@ -197,6 +198,7 @@ static VOID xa_nn_dilated_conv2d_depthwise_nchw_init
+     p_mem = (p_mem + circ_buf_size);
+     p_state->p_scratch = (pVOID)p_mem;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ static WORD32 gcd(WORD32 a, WORD32 b)
+ {
+@@ -266,6 +268,7 @@ static WORD32 xa_nn_dilated_conv2d_depthwise_nhwc_getsize
+     }
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ static VOID xa_nn_conv2d_depthwise_nhwc_init
+ (pVOID p_scratch
+  ,WORD32 input_height
+@@ -353,6 +356,7 @@ static VOID xa_nn_dilated_conv2d_depthwise_nhwc_init
+     p_mem = (p_mem + circ_buf_size);
+     p_state->p_scratch = (pVOID)p_mem;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ static WORD32 xa_nn_dilated_conv2d_depthwise_getsize_generic
+ (WORD32 input_height
+@@ -492,6 +496,8 @@ WORD32 xa_nn_conv2d_depthwise_getsize
+ 
+   return total_size;
+ }
++
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ VOID xa_nn_conv2d_depthwise_init
+ (pVOID p_scratch
+  ,WORD32 input_height
+@@ -632,6 +638,7 @@ VOID xa_nn_dilated_conv2d_depthwise_init
+                 ,p_pad_val);
+     }
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ WORD32 xa_nn_dilated_conv2d_depthwise_getsize
+ (WORD32 input_height
+diff --git a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxasym8s.c b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxasym8s.c
+index c4f5804..28d4d65 100644
+--- a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxasym8s.c
++++ b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxasym8s.c
+@@ -630,7 +630,7 @@ WORD32 xa_nn_conv2d_std_per_chan_sym8sxasym8s(
+       ,inp_h
+       ,input_channels
+       ,ker_h
+-      ,kernel_width
++      ,ker_w
+       ,y_str
+       ,y_pad
+       ,out_h
+diff --git a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxsym16s.c b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxsym16s.c
+index a8d82fd..793eb16 100644
+--- a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxsym16s.c
++++ b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_sym8sxsym16s.c
+@@ -497,7 +497,7 @@ WORD32 inp_h, inp_w, ker_h, ker_w, x_str, y_str, x_pad, y_pad, out_h, out_w;
+       ,inp_h
+       ,input_channels
+       ,ker_h
+-      ,kernel_width
++      ,ker_w
+       ,y_str
+       ,y_pad
+       ,out_h
+@@ -510,7 +510,7 @@ WORD32 inp_h, inp_w, ker_h, ker_w, x_str, y_str, x_pad, y_pad, out_h, out_w;
+       ,inp_h
+       ,input_channels
+       ,ker_h
+-      ,kernel_width
++      ,ker_w
+       ,y_str
+       ,y_pad
+       ,out_h
+diff --git a/algo/kernels/cnn/hifi4/xa_nn_transpose_conv_circ_buf.c b/algo/kernels/cnn/hifi4/xa_nn_transpose_conv_circ_buf.c
+index 4a2f875..36903ee 100644
+--- a/algo/kernels/cnn/hifi4/xa_nn_transpose_conv_circ_buf.c
++++ b/algo/kernels/cnn/hifi4/xa_nn_transpose_conv_circ_buf.c
+@@ -117,6 +117,7 @@ WORD32 xa_nn_transpose_conv_getsize
+     return total_size;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ VOID xa_nn_transpose_conv_init_state(
+     VOID *p_scratch,
+     VOID *p_kernel,
+@@ -182,3 +183,5 @@ VOID xa_nn_transpose_conv_init_state(
+   AE_SETCBEGIN0(p_state->cir_buf.p_begin);
+   AE_SETCEND0(p_state->cir_buf.p_end);
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
++
+diff --git a/algo/kernels/pool/hifi4/xa_nn_avgpool.c b/algo/kernels/pool/hifi4/xa_nn_avgpool.c
+index d7481e8..5fc8963 100644
+--- a/algo/kernels/pool/hifi4/xa_nn_avgpool.c
++++ b/algo/kernels/pool/hifi4/xa_nn_avgpool.c
+@@ -24,6 +24,7 @@
+ #include "xa_nnlib_kernels_api.h"
+ #include "xa_nn_avgpool_state.h"
+ #include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common_macros.h"
+ 
+ WORD32 xa_nn_avgpool_getsize_nchw(
+     WORD32 inp_precision,
+@@ -86,7 +87,7 @@ WORD32 xa_nn_avgpool_getsize_nchw(
+         den_array_size = 0;
+     /* Output scratch buffer size */
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
++    full_buf_width = MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
+     full_buf_width = ALIGNED_SIZE(full_buf_width, ALIGNMENT/2);
+     /* Need 2 rows of padded input width as acratch for temp output */
+     full_out_width = ALIGNED_SIZE(full_buf_width + kernel_width, 4);
+@@ -150,7 +151,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+ 
+         if(kernel_height <= (int)MAX_HEIGHT_16_BIT_ACC) // Accumulation in 16 bit container
+         {
+-            zero_mem_bytes = XT_MAX(sizeof(UWORD8)*cw_plane_size, sizeof(WORD16)*input_channels);
++            zero_mem_bytes = MAX((int)(sizeof(UWORD8)*cw_plane_size), (int)(sizeof(WORD16)*input_channels));
+ 
+             total_size = ALIGNED_SIZE(sizeof(WORD32)* out_height, ALIGNMENT) +
+                          ALIGNED_SIZE(sizeof(WORD32)* out_width, ALIGNMENT) +
+@@ -162,7 +163,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+         }
+         else  // Accumulation in 32 bit container
+         {
+-            zero_mem_bytes = XT_MAX(sizeof(UWORD8)*cw_plane_size, sizeof(WORD32)*input_channels);
++            zero_mem_bytes = MAX((int)(sizeof(UWORD8)*cw_plane_size), (int)(sizeof(WORD32)*input_channels));
+ 
+             total_size = ALIGNED_SIZE(sizeof(WORD32)*out_height, ALIGNMENT) +
+                          ALIGNED_SIZE(sizeof(WORD32)*out_width, ALIGNMENT) +
+@@ -179,7 +180,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+         int zero_mem_bytes;
+ 
+         cw_plane_size = input_width*input_channels;
+-        zero_mem_bytes = XT_MAX(sizeof(WORD16)*cw_plane_size, sizeof(WORD32)*input_channels);
++        zero_mem_bytes = MAX((int)(sizeof(WORD16)*cw_plane_size), (int)(sizeof(WORD32)*input_channels));
+ 
+         total_size = ALIGNED_SIZE(sizeof(WORD32)*out_height, ALIGNMENT) +
+             ALIGNED_SIZE(sizeof(WORD32)*out_width, ALIGNMENT) +
+@@ -259,7 +260,7 @@ WORD32 xa_nn_avgpool_getsize(
+         den_array_size = 0;
+     /* Output scratch buffer size */
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
++    full_buf_width = MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
+     full_buf_width = ALIGNED_SIZE(full_buf_width, ALIGNMENT/2);
+     /* Need 2 rows of padded input width as acratch for temp output */
+     full_out_width = ALIGNED_SIZE(full_buf_width + kernel_width, 4);
+diff --git a/algo/kernels/pool/hifi4/xa_nn_maxpool.c b/algo/kernels/pool/hifi4/xa_nn_maxpool.c
+index 5ffd08a..5140c92 100644
+--- a/algo/kernels/pool/hifi4/xa_nn_maxpool.c
++++ b/algo/kernels/pool/hifi4/xa_nn_maxpool.c
+@@ -24,6 +24,7 @@
+ #include "xa_nnlib_kernels_api.h"
+ #include "xa_nn_maxpool_state.h"
+ #include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common_macros.h"
+ 
+ WORD32 xa_nn_maxpool_getsize_nchw(
+     WORD32 inp_precision,
+@@ -76,7 +77,7 @@ WORD32 xa_nn_maxpool_getsize_nchw(
+     state_size = ALIGNED_SIZE(sizeof(xa_nn_maxpool_state_t), ALIGNMENT);
+     /* Output scratch buffer size */
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, x_padding + input_width);
++    full_buf_width = MAX(full_buf_width, x_padding + input_width);
+     full_buf_width = ALIGNED_SIZE(full_buf_width, ALIGNMENT/2);
+     /* maxpool: Need 2 rows of padded input width as acratch for temp output */
+     full_out_width = ALIGNED_SIZE(full_buf_width + kernel_width, 4);
+@@ -264,6 +265,7 @@ WORD32 xa_nn_maxpool_getsize(
+ }
+ #endif
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ WORD32 xa_nn_maxpool_init(
+     WORD32 inp_precision,
+     pVOID  p_scratch)
+@@ -300,3 +302,4 @@ WORD32 xa_nn_maxpool_init(
+     p_state->p_scratch = (pVOID)p_mem;
+     return 0;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+diff --git a/algo/kernels/reorg/hifi4/xa_nn_concat_8.c b/algo/kernels/reorg/hifi4/xa_nn_concat_8.c
+new file mode 100644
+index 0000000..e11f5eb
+--- /dev/null
++++ b/algo/kernels/reorg/hifi4/xa_nn_concat_8.c
+@@ -0,0 +1,178 @@
++/*******************************************************************************
++* Copyright (c) 2018-2024 Cadence Design Systems, Inc.
++*
++* Permission is hereby granted, free of charge, to any person obtaining
++* a copy of this software and associated documentation files (the
++* "Software"), to use this Software with Cadence processor cores only and
++* not with any other processors and platforms, subject to
++* the following conditions:
++*
++* The above copyright notice and this permission notice shall be included
++* in all copies or substantial portions of the Software.
++*
++* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++
++******************************************************************************/
++#include "xa_type_def.h"
++#include "xa_nn_common.h"
++#include "xa_nnlib_kernels_api.h"
++#include "xa_nnlib_common_macros.h"
++#include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common.h"
++
++WORD32 xa_nn_concat_8_8(WORD8 * __restrict__ p_out
++                        ,const WORD32 *const p_out_shape
++                        ,const WORD8 **pp_inps
++                        ,const WORD32 *const *pp_inps_shape
++                        ,WORD32 num_out_dims
++                        ,WORD32 num_inp
++                        ,WORD32 num_inp_dims
++                        ,WORD32 axis)
++{
++  XA_NNLIB_ARG_CHK_PTR(p_out, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_out_shape, -1);
++  XA_NNLIB_ARG_CHK_PTR(pp_inps, -1);
++  XA_NNLIB_ARG_CHK_PTR(pp_inps_shape, -1);
++  /* Pointer alignment checks */
++  XA_NNLIB_ARG_CHK_ALIGN(p_out_shape, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(pp_inps, sizeof(WORD8 *), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(pp_inps_shape, sizeof(WORD32 *), -1);
++  //Validate Arguments
++  XA_NNLIB_ARG_CHK_COND((num_out_dims <= 0 || num_out_dims > 6), -1);
++  XA_NNLIB_ARG_CHK_COND((num_inp <= 0 || num_inp > 10), -1);
++  XA_NNLIB_ARG_CHK_COND((num_inp_dims != num_out_dims), -1);
++  XA_NNLIB_ARG_CHK_COND((axis < -num_out_dims || axis >= num_out_dims), -1);
++
++  int i = 0, j = 0;
++  for(i = 0; i < num_inp; i++)
++  {
++    XA_NNLIB_ARG_CHK_PTR(pp_inps[i], -1);
++    XA_NNLIB_ARG_CHK_PTR(pp_inps_shape[i], -1);
++    XA_NNLIB_ARG_CHK_ALIGN(pp_inps_shape[i], sizeof(WORD32), -1);
++  }
++  for(i = 0; i < num_out_dims; i++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_out_shape[i] <= 0), -1);
++    for(j = 0; j < num_inp; j++)
++    {
++      XA_NNLIB_ARG_CHK_COND((pp_inps_shape[j][i] <= 0), -1);
++    }
++  }
++
++  if(axis < 0)
++    axis = num_out_dims + axis;
++
++  WORD32 concat_size = 0;
++  for (int i = 0; i < num_inp; i++)
++  {
++    for(int j = 0; j < num_out_dims; j++)
++    {
++      if(j != axis)
++      {
++        XA_NNLIB_ARG_CHK_COND((pp_inps_shape[i][j] != p_out_shape[j]), -1);
++      }
++    }
++    concat_size += pp_inps_shape[i][axis];
++  }
++
++  XA_NNLIB_ARG_CHK_COND((p_out_shape[axis] != concat_size), -1);
++
++  //Calculate outer and inner size for axis
++  WORD32 outer_size = 1;
++  for(int i = 0; i < axis; i++)
++  {
++    outer_size *= p_out_shape[i];
++  }
++
++  WORD32 base_inner_size = 1;
++  for(int i = axis + 1; i < num_out_dims; i++)
++  {
++    base_inner_size *= p_out_shape[i];
++  }
++
++  WORD8 *ptmp_out = p_out;
++  for(int i = 0; i < num_inp; i++)
++  {
++    const WORD32 copy_size = pp_inps_shape[i][axis] * base_inner_size;
++    WORD8 *output_ptr = ptmp_out;
++    const WORD8* input_ptr = pp_inps[i];
++    if(copy_size <= 8 && ((copy_size & 1) == 0)
++      && (((concat_size * base_inner_size) & 1) == 0)
++      && (((unsigned)input_ptr & 1) == 0) && (((unsigned)output_ptr & 1) == 0))
++    {
++      for(int k = 0; k < outer_size; k++)
++      {
++        const ae_int16 *pae_inp = (const ae_int16 *)input_ptr;
++        ae_int16 *pae_out = (ae_int16 *)output_ptr;
++        for(int ic = 0; ic < (copy_size >> 1); ic++)
++        {
++          pae_out[ic] = pae_inp[ic];
++        }
++        input_ptr += copy_size;
++        output_ptr += concat_size * base_inner_size;
++      }
++    }
++    else if(((copy_size & 1) == 0) && (((concat_size * base_inner_size) & 1) == 0)
++      && (((unsigned)input_ptr & 1) == 0) && (((unsigned)output_ptr & 1) == 0))
++    {
++      for(int k = 0; k < outer_size; k++)
++      {
++        const ae_int16x4 *pae_inp = (const ae_int16x4 *)input_ptr;
++        ae_int16x4 *pae_out = (ae_int16x4 *)output_ptr;
++        ae_valign inp_a, out_a;
++        inp_a = AE_LA64_PP(pae_inp);
++        out_a = AE_ZALIGN64();
++        for(int ic = 0; ic < (copy_size >> 3); ic++)
++        {
++          ae_int16x4 d0;
++          AE_LA16X4_IP(d0, inp_a, pae_inp);
++          AE_SA16X4_IP(d0, out_a, pae_out);
++        }
++        AE_SA64POS_FP(out_a, pae_out);
++        const ae_int16 *puae_inp = (const ae_int16 *)pae_inp;
++        ae_int16 *puae_out = (ae_int16 *)pae_out;
++        for(int ic = 0; ic < ((copy_size >> 1) & 3); ic++)
++        {
++          puae_out[ic] = puae_inp[ic];
++        }
++        input_ptr += copy_size;
++        output_ptr += concat_size * base_inner_size;
++      }
++    }
++    else
++    {
++      for(int k = 0; k < outer_size; k++)
++      {
++        const ae_int24x2 *pae_inp = (const ae_int24x2 *)input_ptr;
++        ae_int24x2 *pae_out = (ae_int24x2 *)output_ptr;
++        ae_valign inp_a, out_a;
++        inp_a = AE_LA64_PP(pae_inp);
++        out_a = AE_ZALIGN64();
++
++        int copy_size_by6 = AE_MOVAD32_H(AE_MOVINT32X2_FROMINT64(AE_MUL32_LL(copy_size, 0x2AAAAAAB)));
++        int copy_size_rem_start = 6*copy_size_by6;
++        for(int ic = 0; ic < copy_size_by6; ic++)
++        {
++          ae_int24x2 d0;
++          AE_LA24X2_IP(d0, inp_a, pae_inp);
++          AE_SA24X2_IP(d0, out_a, pae_out);
++        }
++        AE_SA64POS_FP(out_a, pae_out);
++        for(int ic = copy_size_rem_start; ic < copy_size; ic++)
++        {
++          output_ptr[ic] = input_ptr[ic];
++        }
++        input_ptr += copy_size;
++        output_ptr += concat_size * base_inner_size;
++      }
++    }
++    ptmp_out += copy_size;
++  }
++  return 0;
++}
+diff --git a/algo/kernels/reorg/hifi4/xa_nn_transpose_16.c b/algo/kernels/reorg/hifi4/xa_nn_transpose_16.c
+new file mode 100644
+index 0000000..4488528
+--- /dev/null
++++ b/algo/kernels/reorg/hifi4/xa_nn_transpose_16.c
+@@ -0,0 +1,228 @@
++/*******************************************************************************
++* Copyright (c) 2018-2024 Cadence Design Systems, Inc.
++*
++* Permission is hereby granted, free of charge, to any person obtaining
++* a copy of this software and associated documentation files (the
++* "Software"), to use this Software with Cadence processor cores only and
++* not with any other processors and platforms, subject to
++* the following conditions:
++*
++* The above copyright notice and this permission notice shall be included
++* in all copies or substantial portions of the Software.
++*
++* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++
++******************************************************************************/
++#include "xa_nnlib_common.h"
++
++/*
++ * Currently only supports upto 5D input tensors.
++ * 1/2/3/4 D input tensors will be scaled up to 5D.
++ * For example, 2x3 -> 1x1x1x2x3.
++ */
++
++WORD32 xa_nn_transpose_16_16(WORD16 * __restrict__ p_out
++                    ,const WORD32 *const p_out_shape
++                    ,const WORD16 * __restrict__ p_inp
++                    ,const WORD32 *const p_inp_shape
++                    ,const WORD32 * __restrict__ p_permute_vec
++                    ,WORD32 num_out_dims
++                    ,WORD32 num_inp_dims)
++{
++  /* NULL pointer checks */
++  XA_NNLIB_ARG_CHK_PTR(p_out, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_inp, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_permute_vec, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_out_shape, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_inp_shape, -1);
++
++  /* Invalid input checks */
++  XA_NNLIB_ARG_CHK_COND(((num_inp_dims <= 0) || (num_inp_dims > 5)), -1);
++  XA_NNLIB_ARG_CHK_COND((num_out_dims != num_inp_dims), -1);
++
++  int itr = 0;
++  for(itr=0; itr < num_inp_dims; itr++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_inp_shape[itr] <= 0), -1);
++  }
++  for(itr=0; itr < num_out_dims; itr++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_out_shape[itr] <= 0), -1);
++  }
++
++  /* Output shape provided must be correct based on input
++   * shape and permute values */
++  for(itr=0; itr < num_out_dims; itr++)
++  {
++    int output_dim = p_out_shape[itr];
++    int expected_dim = p_inp_shape[p_permute_vec[itr]];
++    XA_NNLIB_ARG_CHK_COND((output_dim != expected_dim), -1);
++  }
++
++  /* Pointer alignment checks */
++  XA_NNLIB_ARG_CHK_ALIGN(p_out, sizeof(WORD16), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_inp, sizeof(WORD16), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_permute_vec, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_out_shape, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_inp_shape, sizeof(WORD32), -1);
++
++  /* Promoting lesser dim tensors to 5D tensors.
++   * Also updating the permute_vec and shapes as needed for optimization */
++  int p_5D_inp_shape[5] = {1, 1, 1, 1, 1};
++  int p_5D_out_shape[5] = {1, 1, 1, 1, 1};
++  int p_5D_permute_vec[5] = {0, 1, 2, 3, 4};
++
++  /* Check if any inner inp dimension is same in the output */
++  int last_dim_same = 1, last_n_same_dim = 0;
++  itr = num_inp_dims - 1;
++  while(itr >= 0)
++  {
++    last_n_same_dim = (last_dim_same && (p_permute_vec[itr] == itr)) ? (last_n_same_dim + 1) : last_n_same_dim;
++    last_dim_same = (p_permute_vec[itr] == itr) ? last_dim_same & 1 : last_dim_same & 0;
++    itr--;
++  }
++
++  int dims_added = 5 - num_inp_dims;
++  itr = num_inp_dims - 1;
++  int same_count = last_n_same_dim;
++  int count = 4;
++  while(itr >= 0)
++  {
++    p_5D_inp_shape[count] = (same_count > 0) ? p_5D_inp_shape[count]*p_inp_shape[itr] : p_inp_shape[itr];
++    p_5D_out_shape[count] = (same_count > 0) ? p_5D_out_shape[count]*p_out_shape[itr] : p_out_shape[itr];
++    same_count--;
++    itr--;
++    count = (same_count > 0) ? count : count - 1;
++  }
++
++  itr = num_inp_dims - 1;
++  same_count = (last_n_same_dim) ? num_inp_dims - (last_n_same_dim - 1) : 0;
++  count = 4;
++  while(itr >= 0)
++  {
++    p_5D_permute_vec[count] = (same_count > 0) ? p_permute_vec[itr-(last_n_same_dim - 1)] + dims_added + last_n_same_dim - 1 : p_permute_vec[itr] + dims_added;
++    same_count--;
++    itr--;
++    count--;
++  }
++
++  int out_dim0, out_dim1, out_dim2, out_dim3, out_dim4;
++  int inp_dim1, inp_dim2, inp_dim3, inp_dim4;
++  int inp_stride[5];
++
++  out_dim0 = p_5D_out_shape[0];
++  out_dim1 = p_5D_out_shape[1];
++  out_dim2 = p_5D_out_shape[2];
++  out_dim3 = p_5D_out_shape[3];
++  out_dim4 = p_5D_out_shape[4];
++
++  inp_dim1 = p_5D_inp_shape[1];
++  inp_dim2 = p_5D_inp_shape[2];
++  inp_dim3 = p_5D_inp_shape[3];
++  inp_dim4 = p_5D_inp_shape[4];
++
++  inp_stride[0] = inp_dim1*inp_dim2*inp_dim3*inp_dim4;
++  inp_stride[1] = inp_dim2*inp_dim3*inp_dim4;
++  inp_stride[2] = inp_dim3*inp_dim4;
++  inp_stride[3] = inp_dim4;
++  inp_stride[4] = 1;
++
++  if(last_n_same_dim)
++  {
++    int itr0, itr1, itr2, itr3, itr4;
++    WORD16 *p_inp0 = (WORD16*)p_inp;
++    for(itr0 = 0; itr0 < out_dim0; itr0++)
++    {
++      WORD16 *p_inp1 = p_inp0+(itr0*inp_stride[p_5D_permute_vec[0]]);
++#pragma loop_count min=1
++      for(itr1 = 0; itr1 < out_dim1; itr1++)
++      {
++        WORD16 *p_inp2 = p_inp1+(itr1*inp_stride[p_5D_permute_vec[1]]);
++#pragma loop_count min=1
++        for(itr2 = 0; itr2 < out_dim2; itr2++)
++        {
++          WORD16 *p_inp3 = p_inp2+(itr2*inp_stride[p_5D_permute_vec[2]]);
++#pragma loop_count min=1
++          for(itr3 = 0; itr3 < out_dim3; itr3++, p_out+=out_dim4)
++          {
++            WORD16 *p_inp4 = p_inp3+(itr3*inp_stride[p_5D_permute_vec[3]]);
++            ae_int16x4 *__restrict__ pae_i = (ae_int16x4 *)(p_inp4);
++            ae_int16x4 *__restrict__ pae_o = (ae_int16x4 *)(p_out);
++            ae_valign a_inp = AE_LA64_PP(pae_i);
++            ae_valign a_out = AE_ZALIGN64();
++            ae_int16x4 d0;
++            for(itr4 = 0; itr4 < (out_dim4 >> 2); itr4++)
++            {
++              AE_LA16X4_IP(d0, a_inp, pae_i);
++              AE_SA16X4_IP(d0, a_out, pae_o);
++            }
++            AE_SA64POS_FP(a_out, pae_o);
++            ae_int16 *__restrict__ puae_i = (ae_int16 *)(pae_i);
++            ae_int16 *__restrict__ puae_o = (ae_int16 *)(pae_o);
++#pragma loop_count max=3
++            for(itr4 = 0; itr4 < (out_dim4 & 3); itr4++)
++            {
++              puae_o[itr4] = puae_i[itr4];
++            }
++          }
++        }
++      }
++    }
++  }
++  else
++  {
++    int itr0, itr1, itr2, itr3, itr4;
++    WORD16 *p_inp0 = (WORD16*)p_inp;
++    for(itr0 = 0; itr0 < out_dim0; itr0++)
++    {
++      WORD16 *p_inp1 = p_inp0+(itr0*inp_stride[p_5D_permute_vec[0]]);
++      for(itr1 = 0; itr1 < out_dim1; itr1++)
++      {
++        WORD16 *p_inp2 = p_inp1+(itr1*inp_stride[p_5D_permute_vec[1]]);
++        for(itr2 = 0; itr2 < out_dim2; itr2++)
++        {
++          WORD16 *p_inp3 = p_inp2+(itr2*inp_stride[p_5D_permute_vec[2]]);
++          for(itr3 = 0; itr3 < out_dim3; itr3++)
++          {
++            WORD16 *p_inp4 = p_inp3+(itr3*inp_stride[p_5D_permute_vec[3]]);
++
++            ae_valign a_out = AE_ZALIGN64();
++            for(itr4 = 0; itr4 < (out_dim4 >> 2); itr4++)
++            {
++              ae_int16x4 d0, d1, d2, d3;
++              ae_int16x4 tmp0;
++
++              d1 = AE_L16_X ((ae_int16*)p_inp4, inp_stride[p_5D_permute_vec[4]]<<1);
++              d2 = AE_L16_X ((ae_int16*)p_inp4, 2*inp_stride[p_5D_permute_vec[4]]<<1);
++              d3 = AE_L16_X ((ae_int16*)p_inp4, 3*inp_stride[p_5D_permute_vec[4]]<<1);
++              AE_L16_XP(d0, (ae_int16*)p_inp4, 4*inp_stride[p_5D_permute_vec[4]]<<1);
++
++              tmp0 = AE_SEL16_6543(d0, d1);
++              tmp0 = AE_SEL16_6543(tmp0, d2);
++              tmp0 = AE_SEL16_6543(tmp0, d3);
++
++              AE_SA16X4_IP(tmp0, a_out, (ae_int16x4 *)p_out);
++            }
++            AE_SA64POS_FP(a_out, p_out);
++#pragma loop_count max=3
++            for(itr4 = 0; itr4 < (out_dim4 & 3); itr4++)
++            {
++              ae_int16x4 d0;
++              AE_L16_XP(d0, (ae_int16*)p_inp4, inp_stride[p_5D_permute_vec[4]]<<1);
++              AE_S16_0_IP(d0, (ae_int16 *)p_out, 2);
++            }
++          }
++        }
++      }
++    }
++  }
++
++  return 0;
++}
++
+diff --git a/include/nnlib/xa_nnlib_kernels_api.h b/include/nnlib/xa_nnlib_kernels_api.h
+index c8a0bbb..9898f15 100644
+--- a/include/nnlib/xa_nnlib_kernels_api.h
++++ b/include/nnlib/xa_nnlib_kernels_api.h
+@@ -3039,6 +3039,14 @@
+                     ,WORD32 num_out_dims
+                     ,WORD32 num_inp_dims);
+ 
++  WORD32 xa_nn_transpose_16_16(WORD16 * __restrict__ p_out
++                    ,const WORD32 *const p_out_shape
++                    ,const WORD16 * __restrict__ p_inp
++                    ,const WORD32 *const p_inp_shape
++                    ,const WORD32 * __restrict__ p_permute_vec
++                    ,WORD32 num_out_dims
++                    ,WORD32 num_inp_dims);
++
+   WORD32 xa_nn_batch_norm_3D_8_8(WORD8 * __restrict__ p_out
+                     ,const WORD8 * __restrict__ p_inp
+                     ,const WORD16 * __restrict__ p_alpha
+@@ -3083,6 +3091,14 @@ WORD32 xa_nn_resize_nearest_neighbour_8_8(pWORD8 __restrict__ p_out
+                     ,FLOAT32 width_offset
+                     ,WORD32  align_corners);
+ 
++WORD32 xa_nn_concat_8_8(WORD8 * __restrict__ p_out
++        ,const WORD32 *const p_out_shape
++        ,const WORD8 **p_inps
++        ,const WORD32 *const *pp_inps_shape
++        ,WORD32 num_out_dims
++        ,WORD32 num_inp
++        ,WORD32 num_inp_dims
++        ,WORD32 axis);
+ 
+ 	/* Mapping the functions names from previous naming convension for backward compatibility */
+ #define xa_nn_matXvec_asym8xasym8_asym8 xa_nn_matXvec_asym8uxasym8u_asym8u
+diff --git a/include/nnlib/xa_nnlib_standards.h b/include/nnlib/xa_nnlib_standards.h
+index 88c619a..fb91967 100644
+--- a/include/nnlib/xa_nnlib_standards.h
++++ b/include/nnlib/xa_nnlib_standards.h
+@@ -22,7 +22,9 @@
+ #ifndef __STANDARDS_H__
+ #define __STANDARDS_H__
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include <xtensa/config/core-isa.h>
++#endif
+ 
+ #if defined(__cplusplus)
+ extern "C"
+@@ -151,7 +153,7 @@ typedef struct _xa_nnlib_shape_t{
+ 
+ enum xa_error_severity {
+   xa_severity_nonfatal = 0,
+-  xa_severity_fatal    = (int)0xffffffff
++  xa_severity_fatal    = (unsigned int)0xffffffff
+ };
+ 
+ enum xa_error_class {

--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
@@ -1,0 +1,693 @@
+diff --git a/algo/common/include/xa_nn_common.h b/algo/common/include/xa_nn_common.h
+index 5a45d27..4fa7215 100644
+--- a/algo/common/include/xa_nn_common.h
++++ b/algo/common/include/xa_nn_common.h
+@@ -64,8 +64,10 @@
+ #define STRINGIZE(A) STRINGIZE_NX(A)    /*  Turn A into a string literal after macro-expanding it. */
+ //#include STRINGIZE(PPCAT(cstub,XTENSA_CORE).h)
+ //#include STRINGIZE(PPCAT(PPCAT(cstub,XTENSA_CORE),c.h))
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include "xtensa/tie/xt_hifi3.h"
+ #include "xtensa/config/core-isa.h"
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ #endif
+ 
+ //-----------------------------------------------------
+@@ -89,6 +91,7 @@
+ #define INV_TBL_BITS 7
+ extern const int32_t tab_invQ30[128];
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #if XCHAL_HAVE_NSA
+   #define NSA(n) XT_NSA(n)
+ #else
+@@ -100,6 +103,7 @@ extern const int32_t tab_invQ30[128];
+     return AE_NSAQ56S(t)-8;
+   }
+ #endif
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ #ifdef COMPILER_XTENSA
+   #define ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+@@ -123,11 +127,13 @@ extern const int32_t tab_invQ30[128];
+ #define return_int64(x) {  union {ae_int64  ai;int64_t   i; } r; r.ai = x;  return r.i; }
+ #endif
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #if  defined (__cplusplus) || defined(COMPILER_XTENSA)
+ 
+ #else
+ #error sorry, C compiler is not supported excluding the XCC
+ #endif
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ 
+ 
+ #ifdef COMPILER_MSVC
+diff --git a/algo/common/include/xa_nnlib_common.h b/algo/common/include/xa_nnlib_common.h
+index fcf379a..d66f2a0 100644
+--- a/algo/common/include/xa_nnlib_common.h
++++ b/algo/common/include/xa_nnlib_common.h
+@@ -21,12 +21,16 @@
+ ******************************************************************************/
+ #ifndef __XA_NNLIB_LEGACY_COMPAT_H__
+ #define __XA_NNLIB_LEGACY_COMPAT_H__
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include <xtensa/config/core-isa.h>
+ #include "xtensa/tie/xt_hifi2.h"
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+ #include "xa_nnlib_api.h"
+ #include "xa_nnlib_standards.h"
+ #include "xa_nnlib_err_chk.h"
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include "xa_nnlib_hifi_isa_compat.h"
++#endif
+ #include "xa_nn_common.h"
+ #include "xa_nnlib_common_internal.h"
+ #endif /* __XA_NNLIB_LEGACY_COMPAT_H__ */
+@@ -36,4 +40,4 @@
+ #define XA_HAVE_HIFI3_CORE 1
+ #else
+ #define XA_HAVE_HIFI3_CORE 0
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/algo/common/include/xa_nnlib_common_macros_hifi5.h b/algo/common/include/xa_nnlib_common_macros_hifi5.h
+index b2ac8e3..9ad396d 100644
+--- a/algo/common/include/xa_nnlib_common_macros_hifi5.h
++++ b/algo/common/include/xa_nnlib_common_macros_hifi5.h
+@@ -28,6 +28,8 @@
+ #define NULL (void *)0
+ #endif /* NULL */
+ 
++#define MAX(a, b)   (((a) > (b)) ? (a) : (b))
++
+ /* Macros for memcpy */
+ #define MEMCPY_8b(out, inp, N) \
+ { \
+diff --git a/algo/kernels/basic/hifi5/xa_nn_reduce_asym8s_asym8s.c b/algo/kernels/basic/hifi5/xa_nn_reduce_asym8s_asym8s.c
+index 6fdcbe5..c079731 100644
+--- a/algo/kernels/basic/hifi5/xa_nn_reduce_asym8s_asym8s.c
++++ b/algo/kernels/basic/hifi5/xa_nn_reduce_asym8s_asym8s.c
+@@ -80,6 +80,7 @@ WORD32 xa_nn_reduce_getsize_nhwc(WORD32 inp_precision
+     return 0;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ /*
+  * Currently only supports upto 4D input tensors.
+  * 1/2/3 D input tensors will be scaled up to 4D.
+@@ -1512,3 +1513,4 @@ WORD32 xa_nn_reduce_mean_4D_asym8s_asym8s(WORD8 * __restrict__ p_out
+ 
+   return 0;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_circ_buf.c b/algo/kernels/cnn/hifi5/xa_nn_circ_buf.c
+index 7b49a65..2ce9e25 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_circ_buf.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_circ_buf.c
+@@ -45,7 +45,7 @@ int xa_nn_circ_buf_nchw_getsize(
+   }
+ 
+   circ_buf_width = kernel_width + ((output_width - 1) * x_stride);
+-  circ_buf_width = XT_MAX(circ_buf_width, x_padding + input_width);
++  circ_buf_width = MAX(circ_buf_width, x_padding + input_width);
+ 
+   /* Align circ_buf_width to 8 for 8-bit and 16-bit inputs to make L8X8 and
+   L16X4X2 loads possible */
+@@ -349,7 +349,7 @@ int xa_nn_circ_buf_nhwc_getsize(
+   int size_in_bytes;
+ 
+   circ_buf_height = kernel_height + ((output_height - 1) * y_stride);
+-  circ_buf_height = XT_MAX(circ_buf_height, (y_padding + input_height + dilation_height - 1)/dilation_height);
++  circ_buf_height = MAX(circ_buf_height, (y_padding + input_height + dilation_height - 1)/dilation_height);
+ 
+   if(bytewidth == 4)
+   {
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
+index e3ea1be..a377a41 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
+@@ -77,7 +77,7 @@ static WORD32 xa_nn_dilated_conv2d_depthwise_nchw_getsize
+   circ_buf_size = ALIGNED_SIZE(circ_buf_size, ALIGNMENT_16);
+ 
+   circ_buf_width = dilated_kernel_width + ((output_width - 1) * x_stride);
+-  circ_buf_width = XT_MAX(circ_buf_width, x_padding+input_width);
++  circ_buf_width = MAX(circ_buf_width, x_padding+input_width);
+   if(circ_buf_bytewidth == 1 || circ_buf_bytewidth == 2)
+     circ_buf_width = ALIGNED_SIZE(circ_buf_width, 8);
+   else
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_transpose_conv_circ_buf.c b/algo/kernels/cnn/hifi5/xa_nn_transpose_conv_circ_buf.c
+index 1135ba0..2c2cd33 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_transpose_conv_circ_buf.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_transpose_conv_circ_buf.c
+@@ -111,6 +111,7 @@ WORD32 xa_nn_transpose_conv_getsize
+     return total_size;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ VOID xa_nn_transpose_conv_init_state(
+     VOID *p_scratch,
+     VOID *p_kernel,
+@@ -165,3 +166,5 @@ VOID xa_nn_transpose_conv_init_state(
+   AE_SETCEND0(p_state->cir_buf.p_end);
+ 
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
++
+diff --git a/algo/kernels/pool/hifi5/xa_nn_avgpool.c b/algo/kernels/pool/hifi5/xa_nn_avgpool.c
+index fa2bc14..b050dc9 100644
+--- a/algo/kernels/pool/hifi5/xa_nn_avgpool.c
++++ b/algo/kernels/pool/hifi5/xa_nn_avgpool.c
+@@ -24,6 +24,7 @@
+ #include "xa_nnlib_kernels_api.h"
+ #include "xa_nn_avgpool_state.h"
+ #include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common_macros_hifi5.h"
+ 
+ WORD32 xa_nn_avgpool_getsize_nchw(
+     WORD32 inp_precision,
+@@ -86,7 +87,7 @@ WORD32 xa_nn_avgpool_getsize_nchw(
+         den_array_size = 0;
+     /* Output scratch buffer size */
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
++    full_buf_width = MAX(full_buf_width, ALIGNED_SIZE(x_padding, 2)+input_width);
+     full_buf_width = ALIGNED_SIZE(full_buf_width, ALIGNMENT/2);
+     /* Need 2 rows of padded input width as acratch for temp output */
+     full_out_width = ALIGNED_SIZE(full_buf_width + kernel_width, 4);
+@@ -150,7 +151,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+ 
+         if(kernel_height <= (int)MAX_HEIGHT_16_BIT_ACC) // Accumulation in 16 bit container
+         {
+-            zero_mem_bytes = XT_MAX(sizeof(UWORD8)*cw_plane_size, sizeof(WORD16)*input_channels);
++            zero_mem_bytes = MAX((int)(sizeof(UWORD8)*cw_plane_size), (int)(sizeof(WORD16)*input_channels));
+ 
+             total_size = ALIGNED_SIZE(sizeof(WORD32)* out_height, ALIGNMENT) +
+                          ALIGNED_SIZE(sizeof(WORD32)* out_width, ALIGNMENT) +
+@@ -162,7 +163,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+         }
+         else  // Accumulation in 32 bit container
+         {
+-            zero_mem_bytes = XT_MAX(sizeof(UWORD8)*cw_plane_size, sizeof(WORD32)*input_channels);
++            zero_mem_bytes = MAX((int)(sizeof(UWORD8)*cw_plane_size), (int)(sizeof(WORD32)*input_channels));
+ 
+             total_size = ALIGNED_SIZE(sizeof(WORD32)*out_height, ALIGNMENT) +
+                          ALIGNED_SIZE(sizeof(WORD32)*out_width, ALIGNMENT) +
+@@ -179,7 +180,7 @@ WORD32 xa_nn_avgpool_getsize_nhwc(
+         int zero_mem_bytes;
+ 
+         cw_plane_size = input_width*input_channels;
+-        zero_mem_bytes = XT_MAX(sizeof(WORD16)*cw_plane_size, sizeof(WORD32)*input_channels);
++        zero_mem_bytes = MAX((int)(sizeof(WORD16)*cw_plane_size), (int)(sizeof(WORD32)*input_channels));
+ 
+         total_size = ALIGNED_SIZE(sizeof(WORD32)*out_height, ALIGNMENT) +
+             ALIGNED_SIZE(sizeof(WORD32)*out_width, ALIGNMENT) +
+@@ -256,6 +257,7 @@ WORD32 xa_nn_avgpool_getsize(
+     return scratch_size;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ VOID xa_nn_avgpool_init(
+     WORD32 inp_precision,
+     pVOID  p_scratch,
+@@ -319,3 +321,4 @@ VOID xa_nn_avgpool_init(
+     /* Initialize output scratch pointer */
+     p_state->p_tmp_out = (pVOID)ALIGN_PTR(p_mem, ALIGNMENT);
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+diff --git a/algo/kernels/pool/hifi5/xa_nn_maxpool.c b/algo/kernels/pool/hifi5/xa_nn_maxpool.c
+index 647ed11..b5bf4dd 100644
+--- a/algo/kernels/pool/hifi5/xa_nn_maxpool.c
++++ b/algo/kernels/pool/hifi5/xa_nn_maxpool.c
+@@ -24,6 +24,7 @@
+ #include "xa_nnlib_kernels_api.h"
+ #include "xa_nn_maxpool_state.h"
+ #include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common_macros_hifi5.h"
+ 
+ WORD32 xa_nn_maxpool_getsize_nchw(
+     WORD32 inp_precision,
+@@ -76,7 +77,7 @@ WORD32 xa_nn_maxpool_getsize_nchw(
+     state_size = ALIGNED_SIZE(sizeof(xa_nn_maxpool_state_t), ALIGNMENT);
+     /* Output scratch buffer size */
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, x_padding + input_width);
++    full_buf_width = MAX(full_buf_width, x_padding + input_width);
+     full_buf_width = ALIGNED_SIZE(full_buf_width, ALIGNMENT/2);
+     /* maxpool: Need 2 rows of padded input width as acratch for temp output */
+     full_out_width = ALIGNED_SIZE(full_buf_width + kernel_width, 4);
+@@ -102,7 +103,7 @@ WORD32 xa_nn_maxpool_getsize_nhwc(WORD32  inp_precision,
+     int full_buf_width;
+     int left_pad_aligned = ALIGNED_SIZE(x_padding, ALIGNMENT);
+     full_buf_width = kernel_width + (out_width - 1)*x_stride;
+-    full_buf_width = XT_MAX(full_buf_width, x_padding + input_width);
++    full_buf_width = MAX(full_buf_width, x_padding + input_width);
+     int right_pad = full_buf_width - (x_padding + input_width);
+     full_buf_width = full_buf_width + left_pad_aligned + right_pad + kernel_width;
+     
+@@ -203,6 +204,7 @@ WORD32 xa_nn_maxpool_getsize(
+     return scratch_size;
+ }
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ WORD32 xa_nn_maxpool_init(
+     WORD32 inp_precision,
+     pVOID  p_scratch,
+@@ -253,3 +255,4 @@ WORD32 xa_nn_maxpool_init(
+     p_state->p_scratch = (pVOID)p_mem;
+     return 0;
+ }
++#endif /* #ifndef ENABLE_SCRATCH_SIZE_API_ONLY */
+diff --git a/algo/kernels/reorg/hifi5/xa_nn_concat_8.c b/algo/kernels/reorg/hifi5/xa_nn_concat_8.c
+new file mode 100644
+index 0000000..3ac35b4
+--- /dev/null
++++ b/algo/kernels/reorg/hifi5/xa_nn_concat_8.c
+@@ -0,0 +1,140 @@
++/*******************************************************************************
++* Copyright (c) 2018-2024 Cadence Design Systems, Inc.
++*
++* Permission is hereby granted, free of charge, to any person obtaining
++* a copy of this software and associated documentation files (the
++* "Software"), to use this Software with Cadence processor cores only and
++* not with any other processors and platforms, subject to
++* the following conditions:
++*
++* The above copyright notice and this permission notice shall be included
++* in all copies or substantial portions of the Software.
++*
++* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++
++******************************************************************************/
++#include "xa_type_def.h"
++#include "xa_nn_common.h"
++#include "xa_nnlib_kernels_api.h"
++#include "xa_nnlib_common_macros_hifi5.h"
++#include "xa_nnlib_err_chk.h"
++#include "xa_nnlib_common.h"
++#include<string.h>
++
++WORD32 xa_nn_concat_8_8(WORD8 * __restrict__ p_out
++                        ,const WORD32 *const p_out_shape
++                        ,const WORD8 **pp_inps
++                        ,const WORD32 *const *pp_inps_shape
++                        ,WORD32 num_out_dims
++                        ,WORD32 num_inp
++                        ,WORD32 num_inp_dims
++                        ,WORD32 axis)
++{
++  XA_NNLIB_ARG_CHK_PTR(p_out, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_out_shape, -1);
++  XA_NNLIB_ARG_CHK_PTR(pp_inps, -1);
++  XA_NNLIB_ARG_CHK_PTR(pp_inps_shape, -1);
++  /* Pointer alignment checks */
++  XA_NNLIB_ARG_CHK_ALIGN(p_out_shape, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(pp_inps, sizeof(WORD8 *), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(pp_inps_shape, sizeof(WORD32 *), -1);
++  //Validate Arguments
++  XA_NNLIB_ARG_CHK_COND((num_out_dims <= 0 || num_out_dims > 6), -1);
++  XA_NNLIB_ARG_CHK_COND((num_inp <= 0 || num_inp > 10), -1);
++  XA_NNLIB_ARG_CHK_COND((num_inp_dims != num_out_dims), -1);
++  XA_NNLIB_ARG_CHK_COND((axis < -num_out_dims || axis >= num_out_dims), -1);
++
++  int i = 0, j = 0;
++  for(i = 0; i < num_inp; i++)
++  {
++    XA_NNLIB_ARG_CHK_PTR(pp_inps[i], -1);
++    XA_NNLIB_ARG_CHK_PTR(pp_inps_shape[i], -1);
++    XA_NNLIB_ARG_CHK_ALIGN(pp_inps_shape[i], sizeof(WORD32), -1);
++  }
++  for(i = 0; i < num_out_dims; i++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_out_shape[i] <= 0), -1);
++    for(j = 0; j < num_inp; j++)
++    {
++      XA_NNLIB_ARG_CHK_COND((pp_inps_shape[j][i] <= 0), -1);
++    }
++  }
++
++  if(axis < 0)
++    axis = num_out_dims + axis;
++
++  WORD32 concat_size = 0;
++  for (int i = 0; i < num_inp; i++)
++  {
++    for(int j = 0; j < num_out_dims; j++)
++    {
++      if(j != axis)
++      {
++        XA_NNLIB_ARG_CHK_COND((pp_inps_shape[i][j] != p_out_shape[j]), -1);
++      }
++    }
++    concat_size += pp_inps_shape[i][axis];
++  }
++
++  XA_NNLIB_ARG_CHK_COND((p_out_shape[axis] != concat_size), -1);
++
++  //Calculate outer and inner size for axis
++  WORD32 outer_size = 1;
++  for(int i = 0; i < axis; i++)
++  {
++    outer_size *= p_out_shape[i];
++  }
++
++  WORD32 base_inner_size = 1;
++  for(int i = axis + 1; i < num_out_dims; i++)
++  {
++    base_inner_size *= p_out_shape[i];
++  }
++
++  {
++    WORD8 *ptmp_out = p_out;
++    for(int i = 0; i < num_inp; i++)
++    {
++      const WORD32 copy_size = pp_inps_shape[i][axis] * base_inner_size;
++
++      if(copy_size < 16)
++      {
++        ae_int8x16 *output_ptr;
++        ae_int8x16 *input_ptr = (ae_int8x16 *)pp_inps[i];
++        ae_valignx2 input_valign, output_valign;
++        input_valign = AE_LA128_PP(input_ptr);
++        ae_int8x8 d_inp1, d_inp2;
++        for(int k = 0; k < outer_size; k++)
++        {
++          output_ptr = (ae_int8x16 *)(ptmp_out + concat_size * base_inner_size * k);
++          output_valign = AE_ZALIGN128();
++          AE_LAV8X8X2_XP(d_inp1, d_inp2, input_valign, input_ptr, copy_size);
++          AE_SAV8X8X2_XP(d_inp1, d_inp2, output_valign, output_ptr, copy_size);
++          AE_SA128POS_FP(output_valign, (void *)output_ptr);
++        }
++        ptmp_out += copy_size;
++      }
++      else
++      {
++        WORD8 *output_ptr = ptmp_out;
++        const WORD8* input_ptr = pp_inps[i];
++
++        for(int k = 0; k < outer_size; k++)
++        {
++          memcpy(output_ptr, input_ptr, copy_size * sizeof(WORD8));
++          input_ptr += copy_size;
++          output_ptr += concat_size * base_inner_size;
++        }
++        ptmp_out += copy_size;
++      }
++    }
++  }
++  return 0;
++
++}
+diff --git a/algo/kernels/reorg/hifi5/xa_nn_transpose_16.c b/algo/kernels/reorg/hifi5/xa_nn_transpose_16.c
+new file mode 100644
+index 0000000..f9b88ed
+--- /dev/null
++++ b/algo/kernels/reorg/hifi5/xa_nn_transpose_16.c
+@@ -0,0 +1,224 @@
++/*******************************************************************************
++* Copyright (c) 2018-2024 Cadence Design Systems, Inc.
++*
++* Permission is hereby granted, free of charge, to any person obtaining
++* a copy of this software and associated documentation files (the
++* "Software"), to use this Software with Cadence processor cores only and
++* not with any other processors and platforms, subject to
++* the following conditions:
++*
++* The above copyright notice and this permission notice shall be included
++* in all copies or substantial portions of the Software.
++*
++* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++
++******************************************************************************/
++#include "xa_nnlib_common.h"
++
++/*
++ * Currently only supports upto 5D input tensors.
++ * 1/2/3/4 D input tensors will be scaled up to 5D.
++ * For example, 2x3 -> 1x1x1x2x3.
++ */
++
++WORD32 xa_nn_transpose_16_16(WORD16 * __restrict__ p_out
++                    ,const WORD32 *const p_out_shape
++                    ,const WORD16 * __restrict__ p_inp
++                    ,const WORD32 *const p_inp_shape
++                    ,const WORD32 * __restrict__ p_permute_vec
++                    ,WORD32 num_out_dims
++                    ,WORD32 num_inp_dims)
++{
++  /* NULL pointer checks */
++  XA_NNLIB_ARG_CHK_PTR(p_out, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_inp, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_permute_vec, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_out_shape, -1);
++  XA_NNLIB_ARG_CHK_PTR(p_inp_shape, -1);
++
++  /* Invalid input checks */
++  XA_NNLIB_ARG_CHK_COND(((num_inp_dims <= 0) || (num_inp_dims > 5)), -1);
++  XA_NNLIB_ARG_CHK_COND((num_out_dims != num_inp_dims), -1);
++
++  int itr = 0;
++  for(itr=0; itr < num_inp_dims; itr++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_inp_shape[itr] <= 0), -1);
++  }
++  for(itr=0; itr < num_out_dims; itr++)
++  {
++    XA_NNLIB_ARG_CHK_COND((p_out_shape[itr] <= 0), -1);
++  }
++
++  /* Output shape provided must be correct based on input
++   * shape and permute values */
++  for(itr=0; itr < num_out_dims; itr++)
++  {
++    int output_dim = p_out_shape[itr];
++    int expected_dim = p_inp_shape[p_permute_vec[itr]];
++    XA_NNLIB_ARG_CHK_COND((output_dim != expected_dim), -1);
++  }
++
++  /* Pointer alignment checks */
++  XA_NNLIB_ARG_CHK_ALIGN(p_out, sizeof(WORD16), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_inp, sizeof(WORD16), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_permute_vec, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_out_shape, sizeof(WORD32), -1);
++  XA_NNLIB_ARG_CHK_ALIGN(p_inp_shape, sizeof(WORD32), -1);
++
++  /* Promoting lesser dim tensors to 5D tensors.
++   * Also updating the permute_vec and shapes as needed for optimization */
++  int p_5D_inp_shape[5] = {1, 1, 1, 1, 1};
++  int p_5D_out_shape[5] = {1, 1, 1, 1, 1};
++  int p_5D_permute_vec[5] = {0, 1, 2, 3, 4};
++
++  /* Check if any inner inp dimension is same in the output */
++  int last_dim_same = 1, last_n_same_dim = 0;
++  itr = num_inp_dims - 1;
++  while(itr >= 0)
++  {
++    last_n_same_dim = (last_dim_same && (p_permute_vec[itr] == itr)) ? (last_n_same_dim + 1) : last_n_same_dim;
++    last_dim_same = (p_permute_vec[itr] == itr) ? last_dim_same & 1 : last_dim_same & 0;
++    itr--;
++  }
++
++  int dims_added = 5 - num_inp_dims;
++  itr = num_inp_dims - 1;
++  int same_count = last_n_same_dim;
++  int count = 4;
++  while(itr >= 0)
++  {
++    p_5D_inp_shape[count] = (same_count > 0) ? p_5D_inp_shape[count]*p_inp_shape[itr] : p_inp_shape[itr];
++    p_5D_out_shape[count] = (same_count > 0) ? p_5D_out_shape[count]*p_out_shape[itr] : p_out_shape[itr];
++    same_count--;
++    itr--;
++    count = (same_count > 0) ? count : count - 1;
++  }
++
++  itr = num_inp_dims - 1;
++  same_count = (last_n_same_dim) ? num_inp_dims - (last_n_same_dim - 1) : 0;
++  count = 4;
++  while(itr >= 0)
++  {
++    p_5D_permute_vec[count] = (same_count > 0) ? p_permute_vec[itr-(last_n_same_dim - 1)] + dims_added + last_n_same_dim - 1 : p_permute_vec[itr] + dims_added;
++    same_count--;
++    itr--;
++    count--;
++  }
++
++  int out_dim0, out_dim1, out_dim2, out_dim3, out_dim4;
++  int inp_dim1, inp_dim2, inp_dim3, inp_dim4;
++  int inp_stride[5];
++
++  out_dim0 = p_5D_out_shape[0];
++  out_dim1 = p_5D_out_shape[1];
++  out_dim2 = p_5D_out_shape[2];
++  out_dim3 = p_5D_out_shape[3];
++  out_dim4 = p_5D_out_shape[4];
++
++  inp_dim1 = p_5D_inp_shape[1];
++  inp_dim2 = p_5D_inp_shape[2];
++  inp_dim3 = p_5D_inp_shape[3];
++  inp_dim4 = p_5D_inp_shape[4];
++
++  inp_stride[0] = inp_dim1*inp_dim2*inp_dim3*inp_dim4;
++  inp_stride[1] = inp_dim2*inp_dim3*inp_dim4;
++  inp_stride[2] = inp_dim3*inp_dim4;
++  inp_stride[3] = inp_dim4;
++  inp_stride[4] = 1;
++
++  if(last_n_same_dim)
++  {
++    int itr0, itr1, itr2, itr3, itr4;
++    WORD16 *p_inp0 = (WORD16*)p_inp;
++    for(itr0 = 0; itr0 < out_dim0; itr0++)
++    {
++      WORD16 *p_inp1 = p_inp0+(itr0*inp_stride[p_5D_permute_vec[0]]);
++#pragma loop_count min=1
++      for(itr1 = 0; itr1 < out_dim1; itr1++)
++      {
++        WORD16 *p_inp2 = p_inp1+(itr1*inp_stride[p_5D_permute_vec[1]]);
++#pragma loop_count min=1
++        for(itr2 = 0; itr2 < out_dim2; itr2++)
++        {
++          WORD16 *p_inp3 = p_inp2+(itr2*inp_stride[p_5D_permute_vec[2]]);
++#pragma loop_count min=1
++          for(itr3 = 0; itr3 < out_dim3; itr3++, p_out+=out_dim4)
++          {
++            WORD16 *p_inp4 = p_inp3+(itr3*inp_stride[p_5D_permute_vec[3]]);
++            ae_int16x8 *__restrict__ pae_i = (ae_int16x8 *)(p_inp4);
++            ae_int16x8 *__restrict__ pae_o = (ae_int16x8 *)(p_out);
++            ae_valignx2 a_inp = AE_LA128_PP(pae_i);
++            ae_valignx2 a_out = AE_ZALIGN128();
++            ae_int16x4 d0,d1;
++            for(itr4 = 0; itr4 < (out_dim4 >> 3); itr4++)
++            {
++              AE_LA16X4X2_IP(d0, d1, a_inp, (ae_int16x8*)pae_i);
++              AE_SA16X4X2_IP(d0, d1, a_out, (ae_int16x8*)pae_o);
++            }
++            AE_LAV16X4X2_XP(d0, d1, a_inp, (ae_int16x8*)pae_i, (out_dim4 & 7)<<1);
++            AE_SAV16X4X2_XP(d0, d1, a_out, (ae_int16x8*)pae_o, (out_dim4 & 7)<<1);
++            AE_SA128POS_FP(a_out, pae_o);
++          }
++        }
++      }
++    }
++  }
++  else
++  {
++    int itr0, itr1, itr2, itr3, itr4;
++    WORD16 *p_inp0 = (WORD16*)p_inp;
++    for(itr0 = 0; itr0 < out_dim0; itr0++)
++    {
++      WORD16 *p_inp1 = p_inp0+(itr0*inp_stride[p_5D_permute_vec[0]]);
++      for(itr1 = 0; itr1 < out_dim1; itr1++)
++      {
++        WORD16 *p_inp2 = p_inp1+(itr1*inp_stride[p_5D_permute_vec[1]]);
++        for(itr2 = 0; itr2 < out_dim2; itr2++)
++        {
++          WORD16 *p_inp3 = p_inp2+(itr2*inp_stride[p_5D_permute_vec[2]]);
++          for(itr3 = 0; itr3 < out_dim3; itr3++)
++          {
++            WORD16 *p_inp4 = p_inp3+(itr3*inp_stride[p_5D_permute_vec[3]]);
++
++            ae_valign a_out = AE_ZALIGN64();
++            for(itr4 = 0; itr4 < (out_dim4 >> 2); itr4++)
++            {
++              ae_int16x4 d0, d1, d2, d3;
++              ae_int16x4 tmp0;
++
++              d1 = AE_L16_X ((ae_int16*)p_inp4, inp_stride[p_5D_permute_vec[4]]<<1);
++              d2 = AE_L16_X ((ae_int16*)p_inp4, 2*inp_stride[p_5D_permute_vec[4]]<<1);
++              d3 = AE_L16_X ((ae_int16*)p_inp4, 3*inp_stride[p_5D_permute_vec[4]]<<1);
++              AE_L16_XP(d0, (ae_int16*)p_inp4, 4*inp_stride[p_5D_permute_vec[4]]<<1);
++
++              tmp0 = AE_SEL16_6543(d0, d1);
++              tmp0 = AE_SEL16_6543(tmp0, d2);
++              tmp0 = AE_SEL16_6543(tmp0, d3);
++
++              AE_SA16X4_IP(tmp0, a_out, (ae_int16x4 *)p_out);
++            }
++            AE_SA64POS_FP(a_out, p_out);
++#pragma loop_count max=3
++            for(itr4 = 0; itr4 < (out_dim4 & 3); itr4++)
++            {
++              ae_int16x4 d0;
++              AE_L16_XP(d0, (ae_int16*)p_inp4, inp_stride[p_5D_permute_vec[4]]<<1);
++              AE_S16_0_IP(d0, (ae_int16 *)p_out, 2);
++            }
++          }
++        }
++      }
++    }
++  }
++
++  return 0;
++}
++
++
+diff --git a/include/nnlib/xa_nnlib_kernels_api.h b/include/nnlib/xa_nnlib_kernels_api.h
+index c8a0bbb..9898f15 100644
+--- a/include/nnlib/xa_nnlib_kernels_api.h
++++ b/include/nnlib/xa_nnlib_kernels_api.h
+@@ -3039,6 +3039,14 @@
+                     ,WORD32 num_out_dims
+                     ,WORD32 num_inp_dims);
+ 
++  WORD32 xa_nn_transpose_16_16(WORD16 * __restrict__ p_out
++                    ,const WORD32 *const p_out_shape
++                    ,const WORD16 * __restrict__ p_inp
++                    ,const WORD32 *const p_inp_shape
++                    ,const WORD32 * __restrict__ p_permute_vec
++                    ,WORD32 num_out_dims
++                    ,WORD32 num_inp_dims);
++
+   WORD32 xa_nn_batch_norm_3D_8_8(WORD8 * __restrict__ p_out
+                     ,const WORD8 * __restrict__ p_inp
+                     ,const WORD16 * __restrict__ p_alpha
+@@ -3083,6 +3091,14 @@ WORD32 xa_nn_resize_nearest_neighbour_8_8(pWORD8 __restrict__ p_out
+                     ,FLOAT32 width_offset
+                     ,WORD32  align_corners);
+ 
++WORD32 xa_nn_concat_8_8(WORD8 * __restrict__ p_out
++        ,const WORD32 *const p_out_shape
++        ,const WORD8 **p_inps
++        ,const WORD32 *const *pp_inps_shape
++        ,WORD32 num_out_dims
++        ,WORD32 num_inp
++        ,WORD32 num_inp_dims
++        ,WORD32 axis);
+ 
+ 	/* Mapping the functions names from previous naming convension for backward compatibility */
+ #define xa_nn_matXvec_asym8xasym8_asym8 xa_nn_matXvec_asym8uxasym8u_asym8u
+diff --git a/include/nnlib/xa_nnlib_standards.h b/include/nnlib/xa_nnlib_standards.h
+index 88c619a..fb91967 100644
+--- a/include/nnlib/xa_nnlib_standards.h
++++ b/include/nnlib/xa_nnlib_standards.h
+@@ -22,7 +22,9 @@
+ #ifndef __STANDARDS_H__
+ #define __STANDARDS_H__
+ 
++#ifndef ENABLE_SCRATCH_SIZE_API_ONLY
+ #include <xtensa/config/core-isa.h>
++#endif
+ 
+ #if defined(__cplusplus)
+ extern "C"
+@@ -151,7 +153,7 @@ typedef struct _xa_nnlib_shape_t{
+ 
+ enum xa_error_severity {
+   xa_severity_nonfatal = 0,
+-  xa_severity_fatal    = (int)0xffffffff
++  xa_severity_fatal    = (unsigned int)0xffffffff
+ };
+ 
+ enum xa_error_class {

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -3,6 +3,7 @@
 MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/add_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -44,13 +44,13 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
 fi
 
 if [[ ${2} == "hifi4" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_09_05_2023.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_19_01_2024.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi4"
-  LIBRARY_MD5="2a54e056aef73a4fcffde4643998501a"
+  LIBRARY_MD5="c1b67dc4707f7801b85f93add4b3e20d"
 elif [[ ${2} == "hifi5" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi5/raw/master/archive/xa_nnlib_hifi5_09_05_2023.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi5/raw/master/archive/xa_nnlib_hifi5_19_01_2024.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi5"
-  LIBRARY_MD5="1deb55ef200bf5dbedc70b99b02140c0"
+  LIBRARY_MD5="cf1b659ebc51ff7f7fea2e7353d4bb15"
 elif [[ ${2} == "vision_p6" ]]; then
   LIBRARY_URL="https://github.com/foss-xtensa/tflmlib_vision/raw/main/archive/xi_tflmlib_vision_p6_22_06_29.zip"
   LIBRARY_DIRNAME="xi_tflmlib_vision_p6"


### PR DESCRIPTION
1. Updated xtensa_downloads.sh to use the latest packages.
2. Updated conv operator integration as per the latest API changes in NNLib.
3. Imported latest NNLib patches for HiFi4 and HiFi5 on nne110_dev.