### PR TITLE
Add bias=NULL support for transpose_conv operator

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -123,7 +123,7 @@ TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node,
     if (input->type == kTfLiteInt16) {
       TFLITE_DCHECK(filter->type == kTfLiteInt8);
       TFLITE_DCHECK(output->type == kTfLiteInt16);
-      if (has_bias && bias->type == kTfLiteInt16) {
+      if (bias->type == kTfLiteInt16) {
         TFLITE_DCHECK(
             context->RequestScratchBufferInArena(
                 context, GetTensorShape(bias).FlatSize() * sizeof(std::int64_t),
@@ -325,47 +325,47 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       int32_t* scratch_buffer = static_cast<int32_t*>(
           context->GetScratchBuffer(context, data.scratch_buffer_index));
 #if defined(HIFI4) || defined(HIFI5)
-        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
-        const RuntimeShape& filter_shape =
-            tflite::micro::GetTensorShape(filter);
-        const RuntimeShape& output_shape =
-            tflite::micro::GetTensorShape(output);
-        const int stride_width = data.params.stride_width;
-        const int stride_height = data.params.stride_height;
-        const int pad_width = data.params.padding_values.width;
-        const int pad_height = data.params.padding_values.height;
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& filter_shape =
+          tflite::micro::GetTensorShape(filter);
+      const RuntimeShape& output_shape =
+          tflite::micro::GetTensorShape(output);
+      const int stride_width = data.params.stride_width;
+      const int stride_height = data.params.stride_height;
+      const int pad_width = data.params.padding_values.width;
+      const int pad_height = data.params.padding_values.height;
 
-        const int batches = MatchingDim(input_shape, 0, output_shape, 0);
-        const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
-        const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+      const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+      const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+      const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
 
-        const int input_height = input_shape.Dims(1);
-        const int input_width = input_shape.Dims(2);
-        const int filter_height = filter_shape.Dims(1);
-        const int filter_width = filter_shape.Dims(2);
-        const int output_height = output_shape.Dims(1);
-        const int output_width = output_shape.Dims(2);
-        const int8_t* input_data =
-            tflite::micro::GetTensorData<int8_t>(input);
-        const int8_t* filter_data =
-            tflite::micro::GetTensorData<int8_t>(filter);
-        const int32_t* bias_data = tflite::micro::GetOptionalTensorData<int32_t>(bias);
-        int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+      const int input_height = input_shape.Dims(1);
+      const int input_width = input_shape.Dims(2);
+      const int filter_height = filter_shape.Dims(1);
+      const int filter_width = filter_shape.Dims(2);
+      const int output_height = output_shape.Dims(1);
+      const int output_width = output_shape.Dims(2);
+      const int8_t* input_data =
+          tflite::micro::GetTensorData<int8_t>(input);
+      const int8_t* filter_data =
+          tflite::micro::GetTensorData<int8_t>(filter);
+      const int32_t* bias_data = tflite::micro::GetOptionalTensorData<int32_t>(bias);
+      int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
 
-        const int num_elements = output_shape.FlatSize();
+      const int num_elements = output_shape.FlatSize();
 
-        for (int b = 0; b < batches; b++) {
-          xa_nn_transpose_conv_sym8sxasym8s(
-              &output_data[b * output_height * output_width * output_depth],
-              const_cast<WORD8*>(
-                  &input_data[b * input_height * input_width * input_depth]),
-              const_cast<WORD8*>(filter_data), const_cast<WORD32*>(bias_data),
-              stride_width, stride_height, pad_width, pad_height, input_depth,
-              output_depth, input_height, input_width, filter_height,
-              filter_width, output_height, output_width, num_elements / batches,
-              data.params.input_offset, data.params.output_offset,
-              data.per_channel_output_shift, data.per_channel_output_multiplier,
-              scratch_buffer);
+      for (int b = 0; b < batches; b++) {
+        xa_nn_transpose_conv_sym8sxasym8s(
+            &output_data[b * output_height * output_width * output_depth],
+            const_cast<WORD8*>(
+                &input_data[b * input_height * input_width * input_depth]),
+            const_cast<WORD8*>(filter_data), const_cast<WORD32*>(bias_data),
+            stride_width, stride_height, pad_width, pad_height, input_depth,
+            output_depth, input_height, input_width, filter_height,
+            filter_width, output_height, output_width, num_elements / batches,
+            data.params.input_offset, data.params.output_offset,
+            data.per_channel_output_shift, data.per_channel_output_multiplier,
+            scratch_buffer);
           int8_t* p_out_temp = &output_data[b * output_height * output_width * output_depth];
           TF_LITE_ENSURE_EQ(context,     
                             xa_nn_vec_activation_min_max_8_8(
@@ -393,7 +393,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           context->GetScratchBuffer(context, data.scratch_buffer_index));
       // TODO(b/192090531): Remove this once all 8x16 transpose conv models use
       // 64-bit biases.
-      if (bias != nullptr && bias->type == kTfLiteInt16) {
+      if (bias->type == kTfLiteInt16) {
         std::int64_t* bias_converted_buffer =
             static_cast<int64_t*>(context->GetScratchBuffer(
                 context, data.bias_converted_buffer_index));

--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -184,32 +184,24 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (input->type == kTfLiteInt8) {
     TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
 #if defined(HIFI4) || defined(HIFI5)
-    if(NumInputs(node) == 4){
-      const int stride_width = params->stride_width;
-      const int stride_height = params->stride_height;
+    const int stride_width = params->stride_width;
+    const int stride_height = params->stride_height;
 
-      const int input_height = SizeOfDimension(input, 1);
-      const int input_width = SizeOfDimension(input, 2);
-      const int input_depth = SizeOfDimension(input, 3);
-      const int output_height = height;
-      const int output_width = width;
-      int32_t scratch_buffer_size = 0;
-      scratch_buffer_size = xa_nn_transpose_conv_getsize(input_height,
-                                input_width, input_depth, filter_height,
-                                filter_width, stride_width, stride_height,
-                                output_height, output_width, num_channels,
-                                PREC_SYM8S, PREC_ASYM8S);
-      TFLITE_DCHECK(context->RequestScratchBufferInArena(
-                        context,
-                        scratch_buffer_size,
-                        &(data->scratch_buffer_index)) == kTfLiteOk);
-    }
-    else{
-      TFLITE_DCHECK(context->RequestScratchBufferInArena(
-                        context,
-                        GetTensorShape(output).FlatSize() * sizeof(int32_t),
-                        &(data->scratch_buffer_index)) == kTfLiteOk);
-    }
+    const int input_height = SizeOfDimension(input, 1);
+    const int input_width = SizeOfDimension(input, 2);
+    const int input_depth = SizeOfDimension(input, 3);
+    const int output_height = height;
+    const int output_width = width;
+    int32_t scratch_buffer_size = 0;
+    scratch_buffer_size = xa_nn_transpose_conv_getsize(input_height,
+                              input_width, input_depth, filter_height,
+                              filter_width, stride_width, stride_height,
+                              output_height, output_width, num_channels,
+                              PREC_SYM8S, PREC_ASYM8S);
+    TFLITE_DCHECK(context->RequestScratchBufferInArena(
+                      context,
+                      scratch_buffer_size,
+                      &(data->scratch_buffer_index)) == kTfLiteOk);
 #else // #if defined(HIFI4) || defined(HIFI5)    
     TFLITE_DCHECK(context->RequestScratchBufferInArena(
                       context,
@@ -333,7 +325,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       int32_t* scratch_buffer = static_cast<int32_t*>(
           context->GetScratchBuffer(context, data.scratch_buffer_index));
 #if defined(HIFI4) || defined(HIFI5)
-      if((bias != NULL) && (bias->type == kTfLiteInt32)){
         const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
         const RuntimeShape& filter_shape =
             tflite::micro::GetTensorShape(filter);
@@ -382,20 +373,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                 data.params.quantized_activation_max, output_height * output_width * output_depth),
                             0);
         }
-      }
-      else{
-        reference_integer_ops::TransposeConv(
-            data.params, data.per_channel_output_multiplier,
-            data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
-            tflite::micro::GetTensorData<int8_t>(input),
-            tflite::micro::GetTensorShape(filter),
-            tflite::micro::GetTensorData<int8_t>(filter),
-            tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<int32_t>(bias),
-            tflite::micro::GetTensorShape(output),
-            tflite::micro::GetTensorData<int8_t>(output),
-            tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);          
-      }
 #else
       reference_integer_ops::TransposeConv(
           data.params, data.per_channel_output_multiplier,


### PR DESCRIPTION
- Transpose conv NNLib APIs already support NULL bias support.
- Updated TFLM integration code to allow NNLib API call when bias=NULL.