### PR TITLE
Xtensa integration files modifications for F32 precision operators - hifi_nnlib_latest_versions

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.h
+++ b/tensorflow/lite/micro/kernels/conv.h
@@ -130,9 +130,9 @@ inline TFLMRegistration Register_CONV_2D_INT16() { return Register_CONV_2D(); }
 #endif  // defined(CMSIS_NN) || defined(XTENSA)
 
 #if defined(XTENSA)
-
 TFLMRegistration Register_CONV_2D_FLOAT32();
-
+#else
+inline TFLMRegistration Register_CONV_2D_FLOAT32() { return Register_CONV_2D(); }
 #endif
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -702,6 +702,9 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
       micro_context->GetTensorCompressionData(node, kConvBiasTensor);
 
 #endif  // USE_TFLM_COMPRESSION
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));  
+  ConvParams op_params = ConvParamsFloat(params, op_data.reference_op_data);
   
   const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
 #ifdef USE_TFLM_COMPRESSION
@@ -719,6 +722,7 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
 
   int output_data_format = 0;
   int out_length = output_height * output_width * output_depth;
+  int err;
   if (filter_height == 1 && filter_width == 1) {
     for (int batch = 0; batch < batches; ++batch) {
       float32_t* p_out_temp;
@@ -733,8 +737,19 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
               const_cast<float32_t*>(bias_data), input_height, input_width,
               input_depth, output_depth, output_data_format),
           0);
+
+      err = xa_nn_vec_activation_min_max_f32_f32(
+          p_out_temp,
+          p_out_temp,
+          op_params.float_activation_min,
+          op_params.float_activation_max,
+          out_length);
+      TF_LITE_ENSURE(context, err == 0);
     }
-  } else {
+  } else if ((filter_depth == input_depth) &&
+           ((params.dilation_width_factor == 1) &&
+            (params.dilation_height_factor == 1)))
+  {
     void* p_scratch = static_cast<void*>(
         context->GetScratchBuffer(context, data.scratch_tensor_index));
 
@@ -742,8 +757,7 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
       float32_t* p_out_temp;
       p_out_temp = &output_data[batch * out_length];
 
-      {
-        if((filter_depth == input_depth) && ((params.dilation_width_factor == 1) && (params.dilation_height_factor == 1))){
+      if((filter_depth == input_depth) && ((params.dilation_width_factor == 1) && (params.dilation_height_factor == 1))){
         TF_LITE_ENSURE_EQ(
             context,
             xa_nn_conv2d_std_f32(
@@ -755,24 +769,31 @@ TfLiteStatus ConvEvalHifiFloat32(TfLiteContext* context, TfLiteNode* node,
                 stride_height, pad_width, pad_height, output_height,
                 output_width,output_data_format, static_cast<void*>(p_scratch)),
             0);
-        }
-        else{
-        TFLITE_DCHECK(node->user_data != nullptr);
-        const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));  
-        tflite::reference_ops::Conv(
-            ConvParamsFloat(params, op_data.reference_op_data),
-            tflite::micro::GetTensorShape(input),
-            tflite::micro::GetTensorData<float>(input),
-            tflite::micro::GetTensorShape(filter),
-            tflite::micro::GetTensorData<float>(filter),
-            tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<float>(bias),
-            tflite::micro::GetTensorShape(output),
-            tflite::micro::GetTensorData<float>(output),
-            tflite::micro::GetTensorShape(nullptr), nullptr);        
-        }
+
+        err = xa_nn_vec_activation_min_max_f32_f32(
+            p_out_temp,
+            p_out_temp,
+            op_params.float_activation_min,
+            op_params.float_activation_max,
+            out_length);
+        TF_LITE_ENSURE(context, err == 0);
       }
     }
+  }
+  else{
+    TFLITE_DCHECK(node->user_data != nullptr);
+    const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));  
+    tflite::reference_ops::Conv(
+        ConvParamsFloat(params, op_data.reference_op_data),
+        tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<float>(input),
+        tflite::micro::GetTensorShape(filter),
+        tflite::micro::GetTensorData<float>(filter),
+        tflite::micro::GetTensorShape(bias),
+        tflite::micro::GetOptionalTensorData<float>(bias),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<float>(output),
+        tflite::micro::GetTensorShape(nullptr), nullptr);        
   }
 
   return kTfLiteOk;

--- a/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
@@ -181,11 +181,18 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalOutput(context, node, kStridedSliceOutputTensor);
   switch (output->type) {
     case kTfLiteFloat32:
+#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+      StridedSlice_int32_hifi(op_params, tflite::micro::GetTensorShape(input),
+                                tflite::micro::GetTensorData<int32_t>(input),
+                                tflite::micro::GetTensorShape(output),
+                                tflite::micro::GetTensorData<int32_t>(output));
+#else
       reference_ops::StridedSlice(op_params,
                                   tflite::micro::GetTensorShape(input),
                                   tflite::micro::GetTensorData<float>(input),
                                   tflite::micro::GetTensorShape(output),
                                   tflite::micro::GetTensorData<float>(output));
+#endif
       break;
     case kTfLiteInt8:
 #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/sub.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/sub.cc
@@ -36,7 +36,7 @@ void* SubInit(TfLiteContext* context, const char* buffer, size_t length) {
   return context->AllocatePersistentBuffer(context, sizeof(OpDataSub));
 }
 
-void EvalSub(TfLiteContext* context, TfLiteNode* node, TfLiteSubParams* params,
+TfLiteStatus EvalSub(TfLiteContext* context, TfLiteNode* node, TfLiteSubParams* params,
              const OpDataSub* data, const TfLiteEvalTensor* input1,
              const TfLiteEvalTensor* input2, TfLiteEvalTensor* output) {
   float output_activation_min, output_activation_max;
@@ -44,6 +44,48 @@ void EvalSub(TfLiteContext* context, TfLiteNode* node, TfLiteSubParams* params,
                            &output_activation_max);
   tflite::ArithmeticParams op_params;
   SetActivationParams(output_activation_min, output_activation_max, &op_params);
+
+#if HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+  const RuntimeShape extended_input1_shape =
+      RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input1));
+  const RuntimeShape extended_input2_shape =
+      RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(input2));
+  const RuntimeShape extended_output_shape =
+      RuntimeShape::ExtendedShape(5, tflite::micro::GetTensorShape(output));
+  const int* input1_dims = extended_input1_shape.DimsData();
+  const int* input2_dims = extended_input2_shape.DimsData();
+  const int* output_dims = extended_output_shape.DimsData();
+
+  int b;
+  int inp1_off = 0;
+  int inp2_off = 0;
+  int out_off;
+  out_off = output_dims[1] * output_dims[2] * output_dims[3] * output_dims[4];
+  if (input1_dims[0] > 1) {
+    inp1_off =
+        input1_dims[1] * input1_dims[2] * input1_dims[3] * input1_dims[4];
+  }
+  if (input2_dims[0] > 1) {
+    inp2_off =
+        input2_dims[1] * input2_dims[2] * input2_dims[3] * input2_dims[4];
+  }
+
+  for (b = 0; b < output_dims[0]; b++) {
+    int err = xa_nn_elm_sub_broadcast_4D_f32xf32_f32(
+        tflite::micro::GetTensorData<float>(output) + b * out_off,
+        output_dims + 1,
+        tflite::micro::GetTensorData<float>(input1) + b * inp1_off,
+        input1_dims + 1,
+        tflite::micro::GetTensorData<float>(input2) + b * inp2_off,
+        input2_dims + 1);
+    TF_LITE_ENSURE(context, err == 0);
+  }
+
+  float* output_data = tflite::micro::GetTensorData<float>(output);
+  xa_nn_vec_activation_min_max_f32_f32(
+      output_data, output_data, op_params.float_activation_min,
+      op_params.float_activation_max, (output_dims[0] * out_off));
+#else  // HIFI_VFPU && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
   if (data->requires_broadcast) {
     tflite::reference_ops::BroadcastSubSlow(
         op_params, tflite::micro::GetTensorShape(input1),
@@ -61,6 +103,8 @@ void EvalSub(TfLiteContext* context, TfLiteNode* node, TfLiteSubParams* params,
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<float>(output));
   }
+#endif
+  return kTfLiteOk;
 }
 
 TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,


### PR DESCRIPTION
1. Added xa_nn_elm_add_broadcast_4D_f32xf32_f32, xa_nn_elm_sub_broadcast_4D_f32xf32_f32 in integration code.
2. Added activation_min_max call after api call in integrations for fully_connected_f32 and conv2d_f32.
3. Modified reference function call for conv2d_f32 operator.
4. Mapped Register_CONV_2D_FLOAT32 function call to Register_CONV_2D, when XTENSA is not defined.
5. Added StridedSlice_int32 function call for Float32 precision of strided slice operator.