### PR TITLE
Handle 32b bias support for 8x16 precision in FC and Conv operators 

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -80,7 +80,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteInt16: {
-      if (bias == nullptr || bias->type == kTfLiteInt32) {
+      if (bias->type == kTfLiteInt32) {
         reference_integer_ops::ConvPerChannel(
             ConvParamsQuantized(params, data),
             data.per_channel_output_multiplier, data.per_channel_output_shift,
@@ -92,7 +92,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
                                                  weights_comp_td,
                                                  data.weights_scratch_index),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<int32_t>(
+            tflite::micro::GetTensorData<int32_t>(
                 micro_context, bias, bias_comp_td, data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),
@@ -101,7 +101,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
 #endif  // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
-      } else if (bias->type == kTfLiteInt64) {
+      } else if (bias == nullptr || bias->type == kTfLiteInt64) {
         reference_integer_ops::ConvPerChannel(
             ConvParamsQuantized(params, data),
             data.per_channel_output_multiplier, data.per_channel_output_shift,
@@ -118,7 +118,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetTensorData<std::int64_t>(bias),
+            tflite::micro::GetOptionalTensorData<std::int64_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -238,7 +238,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt16: {
       switch (filter->type) {
         case kTfLiteInt8: {
-          if (bias == nullptr || bias->type == kTfLiteInt32) {
+          if (bias->type == kTfLiteInt32) {
             data.is_per_channel
                 ? tflite::reference_integer_ops::FullyConnectedPerChannel(
                       FullyConnectedParamsQuantized(data),
@@ -253,7 +253,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
                           micro_context, filter, weights_comp_td,
                           data.weights_scratch_index),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(
+                      tflite::micro::GetTensorData<int32_t>(
                           micro_context, bias, bias_comp_td,
                           data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
@@ -283,7 +283,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
 #endif  // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorShape(output),
                       tflite::micro::GetTensorData<int16_t>(output));
-          } else if (bias->type == kTfLiteInt64) {
+          } else if (bias == nullptr || bias->type == kTfLiteInt64) {
             data.is_per_channel
                 ? tflite::reference_integer_ops::FullyConnectedPerChannel(
                       FullyConnectedParamsQuantized(data),

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -108,7 +108,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteInt16: {
 #if defined(HIFI4) || defined(HIFI5)
-      if (bias->type == kTfLiteInt64) {
+      if (bias == nullptr || bias->type == kTfLiteInt64) {
         return ConvEvalHifiInt16(context, node, params, op_data, input, filter, bias,
                           output);
       }

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
@@ -56,7 +56,7 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
 
 #endif  // USE_TFLM_COMPRESSION
 
-  if (bias == nullptr || bias->type == kTfLiteInt32) {
+  if (bias->type == kTfLiteInt32) {
     reference_integer_ops::ConvPerChannel(
         ConvParamsQuantized(params, op_data),
         op_data.per_channel_output_multiplier, op_data.per_channel_output_shift,
@@ -77,7 +77,7 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
 #endif  // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));
-  } else if (bias->type == kTfLiteInt64) {
+  } else if (bias == nullptr || bias->type == kTfLiteInt64) {
     reference_integer_ops::ConvPerChannel(
         ConvParamsQuantized(params, op_data),
         op_data.per_channel_output_multiplier, op_data.per_channel_output_shift,
@@ -89,7 +89,7 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
                                              weights_comp_td,
                                              op_data.weights_scratch_index),
         tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetTensorData<int64_t>(micro_context, bias, bias_comp_td,
+        tflite::micro::GetOptionalTensorData<int64_t>(micro_context, bias, bias_comp_td,
                                               op_data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorData<int8_t>(filter),

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
@@ -68,12 +68,12 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
                                              weights_comp_td,
                                              op_data.weights_scratch_index),
         tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetOptionalTensorData<int32_t>(
+        tflite::micro::GetTensorData<int32_t>(
             micro_context, bias, bias_comp_td, op_data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorData<int8_t>(filter),
         tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetOptionalTensorData<std::int32_t>(bias),
+        tflite::micro::GetTensorData<std::int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
@@ -94,7 +94,7 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
 #else   // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorData<int8_t>(filter),
         tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetTensorData<std::int64_t>(bias),
+        tflite::micro::GetOptionalTensorData<std::int64_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
@@ -31,7 +31,12 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedInt16(
     TfLiteContext* context, TfLiteNode* node, const OpDataFullyConnected& data,
     const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
     const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
-  
+ 
+  if(bias->type == kTfLiteInt32) {
+    MicroPrintf("Bias type %s (%d) not supported.",
+                TfLiteTypeGetName(bias->type), bias->type);
+    return kTfLiteError;
+  }
   const int64_t* bias_data =
       nullptr != bias ? tflite::micro::GetTensorData<int64_t>(bias) : nullptr;
 


### PR DESCRIPTION
- Moved bias=null case along with bias->type = int64 case in CREF code for Conv() and FC()
- Add error check for unsupported bias type in FC() 8x16 for xtensa_target
- Support bias=null in Conv() 8x16 for xtensa_target.