### PR TITLE
Updates in CREF code for 8x16 FC, Conv and xtensa code for Conv 

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -97,7 +97,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<std::int32_t>(bias),
+            tflite::micro::GetTensorData<std::int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
@@ -113,7 +113,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
                                                  weights_comp_td,
                                                  data.weights_scratch_index),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetTensorData<int64_t>(
+            tflite::micro::GetOptionalTensorData<int64_t>(
                 micro_context, bias, bias_comp_td, data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -259,7 +259,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
 #else   // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorData<int8_t>(filter),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+                      tflite::micro::GetTensorData<int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorShape(output),
                       tflite::micro::GetTensorData<int16_t>(output))
@@ -273,13 +273,13 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
                           micro_context, filter, weights_comp_td,
                           data.weights_scratch_index),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(
+                      tflite::micro::GetTensorData<int32_t>(
                           micro_context, bias, bias_comp_td,
                           data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorData<int8_t>(filter),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+                      tflite::micro::GetTensorData<int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorShape(output),
                       tflite::micro::GetTensorData<int16_t>(output));

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -114,7 +114,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       }
       else if (bias->type == kTfLiteInt32) {
 #else  // defined(HIFI4) || defined(HIFI5)
-      if (bias->type == kTfLiteInt64 || bias->type == kTfLiteInt32) {
+      if (bias == nullptr || bias->type == kTfLiteInt64 || bias->type == kTfLiteInt32) {
 #endif  // defined(HIFI4) || defined(HIFI5)
         return ConvReferenceEvalInt16(context, node);
       }


### PR DESCRIPTION
Streamlined the usage of GetTensorData() and GetOptionalTensorData() in CREF code
Added a condition for bias = nullptr in Xtensa Conv() code.