### PR TITLE
Added git patch for ADD, MUL, SQUARED_DIFF 4D broadcast kernels in HiFi5 NN Lib - hifi_nnlib_latest_versions

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
@@ -1,0 +1,272 @@
+diff --git a/algo/kernels/basic/hifi5/xa_nn_elm_add_quant8.c b/algo/kernels/basic/hifi5/xa_nn_elm_add_quant8.c
+index 1eb2d89..eef1d6b 100644
+--- a/algo/kernels/basic/hifi5/xa_nn_elm_add_quant8.c
++++ b/algo/kernels/basic/hifi5/xa_nn_elm_add_quant8.c
+@@ -734,6 +734,48 @@ WORD32 xa_nn_elm_add_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restrict__ p_ou
+                 1,
+                 p_out_shape[0] * inp1_strides[0]);
+   }
++  else if(inp1_const == 1 || inp2_const == 1)
++  {
++    WORD32 inp1_zb, inp1_ls, inp1_mult;
++    WORD32 inp2_zb, inp2_ls, inp2_mult;
++    inp1_zb = inp1_zero_bias;
++    inp1_ls = inp1_left_shift;
++    inp1_mult = inp1_multiplier;
++    inp2_zb = inp2_zero_bias;
++    inp2_ls = inp2_left_shift;
++    inp2_mult = inp2_multiplier;
++    if(inp1_const == 1)
++    {
++      inp2_zb = inp1_zero_bias;
++      inp2_ls = inp1_left_shift;
++      inp2_mult = inp1_multiplier;
++      inp1_zb = inp2_zero_bias;
++      inp1_ls = inp2_left_shift;
++      inp1_mult = inp2_multiplier;
++
++      const WORD8 *tmp;
++      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
++    }
++    {
++      internal_elm_add_broadcast_asym8sxasym8s_asym8s(
++          p_out_tmp,
++          out_zero_bias,
++          out_left_shift,
++          out_multiplier,
++          out_activation_min,
++          out_activation_max,
++          p_inp1_tmp,
++          inp1_zb,
++          inp1_ls,
++          inp1_mult,
++          p_inp2_tmp,
++          inp2_zb,
++          inp2_ls,
++          inp2_mult,
++          left_shift,
++          p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
++    }
++  }
+   else if(inp1_strides[3] == inp2_strides[3])
+   {
+     WORD32 in_lc, out_lc;
+@@ -810,48 +852,6 @@ WORD32 xa_nn_elm_add_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restrict__ p_ou
+       p_inp2_tmp += inp2_strides[0];
+     }
+   }
+-  else if(inp1_const == 1 || inp2_const == 1)
+-  {
+-    WORD32 inp1_zb, inp1_ls, inp1_mult;
+-    WORD32 inp2_zb, inp2_ls, inp2_mult;
+-    inp1_zb = inp1_zero_bias;
+-    inp1_ls = inp1_left_shift;
+-    inp1_mult = inp1_multiplier;
+-    inp2_zb = inp2_zero_bias;
+-    inp2_ls = inp2_left_shift;
+-    inp2_mult = inp2_multiplier;
+-    if(inp1_const == 1)
+-    {
+-      inp2_zb = inp1_zero_bias;
+-      inp2_ls = inp1_left_shift;
+-      inp2_mult = inp1_multiplier;
+-      inp1_zb = inp2_zero_bias;
+-      inp1_ls = inp2_left_shift;
+-      inp1_mult = inp2_multiplier;
+-
+-      const WORD8 *tmp;
+-      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
+-    }
+-    {
+-      internal_elm_add_broadcast_asym8sxasym8s_asym8s(
+-          p_out_tmp,
+-          out_zero_bias,
+-          out_left_shift,
+-          out_multiplier,
+-          out_activation_min,
+-          out_activation_max,
+-          p_inp1_tmp,
+-          inp1_zb,
+-          inp1_ls,
+-          inp1_mult,
+-          p_inp2_tmp,
+-          inp2_zb,
+-          inp2_ls,
+-          inp2_mult,
+-          left_shift,
+-          p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
+-    }
+-  }
+   else
+   {
+     WORD32 inp1_zb, inp1_ls, inp1_mult;
+diff --git a/algo/kernels/basic/hifi5/xa_nn_elm_mul_quant8.c b/algo/kernels/basic/hifi5/xa_nn_elm_mul_quant8.c
+index 94f3dcf..8ea1f2c 100644
+--- a/algo/kernels/basic/hifi5/xa_nn_elm_mul_quant8.c
++++ b/algo/kernels/basic/hifi5/xa_nn_elm_mul_quant8.c
+@@ -601,6 +601,33 @@ WORD32 xa_nn_elm_mul_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restrict__ p_ou
+                 1,
+                 p_out_shape[0] * inp1_strides[0]);
+   }
++  else if(inp1_const == 1 || inp2_const == 1)
++  {
++    WORD32 inp1_zb;
++    WORD32 inp2_zb;
++    inp1_zb = inp1_zero_bias;
++    inp2_zb = inp2_zero_bias;
++    if(inp1_const == 1)
++    {
++      inp2_zb = inp1_zero_bias;
++      inp1_zb = inp2_zero_bias;
++      const WORD8 *tmp;
++      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
++    }
++
++    internal_elm_mul_broadcast_asym8sxasym8s_asym8s(
++        p_out_tmp,
++        out_zero_bias,
++        out_shift,
++        out_multiplier,
++        out_activation_min,
++        out_activation_max,
++        p_inp1_tmp,
++        inp1_zb,
++        p_inp2_tmp,
++        inp2_zb,
++        p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
++  }
+   else if(inp1_strides[3] == inp2_strides[3])
+   {
+     WORD32 in_lc, out_lc;
+@@ -664,33 +691,6 @@ WORD32 xa_nn_elm_mul_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restrict__ p_ou
+       p_inp2_tmp += inp2_strides[0];
+     }
+   }
+-  else if(inp1_const == 1 || inp2_const == 1)
+-  {
+-    WORD32 inp1_zb;
+-    WORD32 inp2_zb;
+-    inp1_zb = inp1_zero_bias;
+-    inp2_zb = inp2_zero_bias;
+-    if(inp1_strides[3] == 0)
+-    {
+-      inp2_zb = inp1_zero_bias;
+-      inp1_zb = inp2_zero_bias;
+-      const WORD8 *tmp;
+-      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
+-    }
+-
+-    internal_elm_mul_broadcast_asym8sxasym8s_asym8s(
+-        p_out_tmp,
+-        out_zero_bias,
+-        out_shift,
+-        out_multiplier,
+-        out_activation_min,
+-        out_activation_max,
+-        p_inp1_tmp,
+-        inp1_zb,
+-        p_inp2_tmp,
+-        inp2_zb,
+-        p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
+-  }
+   else
+   {
+     WORD32 inp1_zb;
+diff --git a/algo/kernels/basic/hifi5/xa_nn_elm_squared_diff_quant8.c b/algo/kernels/basic/hifi5/xa_nn_elm_squared_diff_quant8.c
+index 1ec8a9a..22913b6 100644
+--- a/algo/kernels/basic/hifi5/xa_nn_elm_squared_diff_quant8.c
++++ b/algo/kernels/basic/hifi5/xa_nn_elm_squared_diff_quant8.c
+@@ -458,6 +458,46 @@ WORD32 xa_nn_elm_squared_diff_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restri
+                 1,
+                 p_out_shape[0] * inp1_strides[0]);
+   }
++  else if(inp1_const == 1 || inp2_const == 1)
++  {
++    WORD32 inp1_zb, inp1_ls, inp1_mult;
++    WORD32 inp2_zb, inp2_ls, inp2_mult;
++    inp1_zb = inp1_zero_bias;
++    inp1_ls = inp1_left_shift;
++    inp1_mult = inp1_multiplier;
++    inp2_zb = inp2_zero_bias;
++    inp2_ls = inp2_left_shift;
++    inp2_mult = inp2_multiplier;
++    /* Reversing the inputs is okay because difference is squared */
++    if(inp1_const == 1)
++    {
++      inp2_zb = inp1_zero_bias;
++      inp2_ls = inp1_left_shift;
++      inp2_mult = inp1_multiplier;
++      inp1_zb = inp2_zero_bias;
++      inp1_ls = inp2_left_shift;
++      inp1_mult = inp2_multiplier;
++      const WORD8 *tmp;
++      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
++    }
++    internal_elm_squared_diff_broadcast_asym8sxasym8s_asym8s(
++        p_out_tmp,
++        out_zero_bias,
++        out_left_shift,
++        out_multiplier,
++        out_activation_min,
++        out_activation_max,
++        p_inp1_tmp,
++        inp1_zb,
++        inp1_ls,
++        inp1_mult,
++        p_inp2_tmp,
++        inp2_zb,
++        inp2_ls,
++        inp2_mult,
++        left_shift,
++        p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
++  }
+   else if(inp1_strides[3] == inp2_strides[3])
+   {
+     WORD32 in_lc, out_lc;
+@@ -536,46 +576,6 @@ WORD32 xa_nn_elm_squared_diff_broadcast_4D_asym8sxasym8s_asym8s(WORD8 * __restri
+       p_inp2_tmp += inp2_strides[0];
+     }
+   }
+-  else if(inp1_const == 1 || inp2_const == 1)
+-  {
+-    WORD32 inp1_zb, inp1_ls, inp1_mult;
+-    WORD32 inp2_zb, inp2_ls, inp2_mult;
+-    inp1_zb = inp1_zero_bias;
+-    inp1_ls = inp1_left_shift;
+-    inp1_mult = inp1_multiplier;
+-    inp2_zb = inp2_zero_bias;
+-    inp2_ls = inp2_left_shift;
+-    inp2_mult = inp2_multiplier;
+-    /* Reversing the inputs is okay because difference is squared */
+-    if(inp1_strides[3] == 0)
+-    {
+-      inp2_zb = inp1_zero_bias;
+-      inp2_ls = inp1_left_shift;
+-      inp2_mult = inp1_multiplier;
+-      inp1_zb = inp2_zero_bias;
+-      inp1_ls = inp2_left_shift;
+-      inp1_mult = inp2_multiplier;
+-      const WORD8 *tmp;
+-      tmp = p_inp1_tmp;   p_inp1_tmp = p_inp2_tmp;    p_inp2_tmp = tmp;
+-    }
+-    internal_elm_squared_diff_broadcast_asym8sxasym8s_asym8s(
+-        p_out_tmp,
+-        out_zero_bias,
+-        out_left_shift,
+-        out_multiplier,
+-        out_activation_min,
+-        out_activation_max,
+-        p_inp1_tmp,
+-        inp1_zb,
+-        inp1_ls,
+-        inp1_mult,
+-        p_inp2_tmp,
+-        inp2_zb,
+-        inp2_ls,
+-        inp2_mult,
+-        left_shift,
+-        p_out_shape[0] * p_out_shape[1] * p_out_shape[2] * p_out_shape[3]);
+-  }
+   else
+   {
+     WORD32 inp1_zb, inp1_ls, inp1_mult;

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -38,7 +38,7 @@ set -e
 source ${3}tensorflow/lite/micro/tools/make/bash_helpers.sh
 
 DOWNLOADS_DIR=${1}
-PATCH=""
+PATCH="../../ext_libs/xa_nnlib_${2}.patch"
 
 if [[ ${2} == "hifi4" ]]; then
   LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_02_11_2025.zip"


### PR DESCRIPTION
1. Added HiFi5 NNLib git patch for performance improvement of special case for ADD, MUL and SQUARED_DIFF 8-bit precision operators.
2. Modified xtensa_download.sh script to apply HiFi NNLib patch correctly.