### PR TITLE
Fixed dilated_conv2d_std_getsize function call and updated Hifi5 NNLib patch for dilated_conv2d_std_v2_per_chan kernel - hifi_nnlib_latest_versions

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -88,9 +88,16 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
     // For HiFi5, with nnlib-hifi5 versions 1.7.0 onwards and for HiFi4 with nnlib-hifi4 versions 2.5.0 onwards, 
     // we use the below dilated_conv2d_std getsize() API. For the earlier versions, "output_channels" argument is not needed.
 #if defined(HIFI5) || defined(HIFI4)
+  if (input->type == kTfLiteInt8) {
     required_scratch = xa_nn_dilated_conv2d_std_getsize(
         input_height, input_depth, filter_height, filter_width, stride_height,
         pad_height, output_height, output_channels, PREC_ASYM8S, params->dilation_height_factor);
+  }
+  else if (input->type == kTfLiteInt16) {
+    required_scratch = xa_nn_dilated_conv2d_std_getsize(
+        input_height, input_depth, filter_height, filter_width, stride_height,
+        pad_height, output_height, output_channels, PREC_SYM16S, params->dilation_height_factor);
+  }
 #endif // defined(HIFI5) || defined(HIFI4)
     TF_LITE_ENSURE(context, required_scratch > 0);
   }

--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi5.patch
@@ -1,0 +1,26 @@
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_sym8sxsym16s.c b/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_sym8sxsym16s.c
+index ea2e6f4..585c58f 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_sym8sxsym16s.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_sym8sxsym16s.c
+@@ -637,8 +637,8 @@ WORD32 xa_nn_dilated_conv2d_std_v2_per_chan_sym8sxsym16s(
+   WORD32 out_width_over_x_r_pad = 0;
+   // Determine x-right padding
+   WORD32 x_r_pad = kernel_width_dilation + (out_width - 1) * x_stride - (x_padding + input_width);//dilation
+-  //x_r_pad = x_r_pad < 0 ? 0 : x_r_pad;
+-  XA_NNLIB_ARG_CHK_COND((x_r_pad<0), -1);
++  x_r_pad = x_r_pad < 0 ? 0 : x_r_pad;
++  // XA_NNLIB_ARG_CHK_COND((x_r_pad<0), -1);
+   if(x_r_pad >= kernel_width_dilation)//dilation
+   {
+     out_width_over_x_r_pad = conv_x_right_pad(x_padding, input_width, x_stride, out_width, out_height, out_channels, out_channels_offset, out_width_offset, out_height_offset, p_bias, p_out, p_out_multiplier, p_out_shift, out_zero_bias, out_activation_min, out_activation_max);
+@@ -647,8 +647,8 @@ WORD32 xa_nn_dilated_conv2d_std_v2_per_chan_sym8sxsym16s(
+ 
+   // Determine y-bottom padding
+   WORD32 y_b_pad = kernel_height_dilation + (out_height - 1) * y_stride - (y_padding + input_height);
+-  //y_b_pad = y_b_pad < 0 ? 0 : y_b_pad;
+-  XA_NNLIB_ARG_CHK_COND((y_b_pad<0), -1);
++  y_b_pad = y_b_pad < 0 ? 0 : y_b_pad;
++  // XA_NNLIB_ARG_CHK_COND((y_b_pad<0), -1);
+ 
+ 
+   XA_NNLIB_ARG_CHK_COND((kernel_height_dilation > ( y_padding + input_height + y_b_pad)), -1);//dilation


### PR DESCRIPTION
Passed appropriate precision to the dilated_conv2d_std_getsize function according to the input type. Added HiFi5 NNLib patch to disable condition checks in the dilated_conv2d_std_v2_per_chan_sym8sxsym16s function