### PR TITLE
Updated Integration layer: updated batch_matmul getsize input argument order, added bias pointer check in ConvPrepareHifi, updated ConvPerChannel call - nne_dev

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/batch_matmul.cc
@@ -409,8 +409,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   }
 
   if (lhs_data->type == kTfLiteInt8) {
-    required_scratch = xa_nn_batch_matmul_getsize(mat_inp1_shape, mat_inp2_shape,
-                          adj_x, !adj_y, -4, -4 );
+    required_scratch = xa_nn_batch_matmul_getsize(mat_inp2_shape, mat_inp1_shape,
+                          !adj_y, adj_x, -4, -4 );
     TF_LITE_ENSURE(context, required_scratch >= 0);
     TF_LITE_ENSURE_OK(
         context, context->RequestScratchBufferInArena(
@@ -418,8 +418,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   }
 
   if (lhs_data->type == kTfLiteInt16) {
-    required_scratch = xa_nn_batch_matmul_getsize(mat_inp1_shape, mat_inp2_shape,
-                          adj_x, !adj_y, -8, -8);
+    required_scratch = xa_nn_batch_matmul_getsize(mat_inp2_shape, mat_inp1_shape,
+                          !adj_y, adj_x, -8, -8);
     TF_LITE_ENSURE(context, required_scratch >= 0);
     TF_LITE_ENSURE_OK(
         context, context->RequestScratchBufferInArena(

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -54,7 +54,7 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
 
   bool inputs_and_bias_ok =
       (input->type == kTfLiteInt8 ||
-      (input->type == kTfLiteInt16 && bias->type == kTfLiteInt64) || 
+      (input->type == kTfLiteInt16 && bias && bias->type == kTfLiteInt64) || 
       input->type == kTfLiteFloat32);
 
   if (inputs_and_bias_ok == 0) {
@@ -661,7 +661,7 @@ TfLiteStatus ConvEvalHifiInt4(TfLiteContext* context, TfLiteNode* node,
           tflite::micro::GetTensorShape(filter),
           filter_data,
           tflite::micro::GetTensorShape(bias),
-          tflite::micro::GetTensorData<int32_t>(bias),
+          tflite::micro::GetOptionalTensorData<int32_t>(bias),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));        
     }


### PR DESCRIPTION
1. Updated the xa_nn_batch_matmul_getsize function call in the integration layer to swap the input shape arrays, aligning their order with the kernel API call
2. Added bias pointer check in the ConvPrepareHifi function.
3. Updated ConvPerChannel function call in ConvEvalHifiInt4 function.