### PR TITLE
[LATEST_VERSIONS][CONV][HIFI]: Fix condition check for 8x16 convolution with 64b bias

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -54,7 +54,7 @@ TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
 
   bool inputs_and_bias_ok =
       (input->type == kTfLiteInt8 ||
-      (input->type == kTfLiteInt16 && bias && bias->type == kTfLiteInt64) || 
+      (input->type == kTfLiteInt16 && (!bias || bias->type == kTfLiteInt64)) || 
       input->type == kTfLiteFloat32);
 
   if (inputs_and_bias_ok == 0) {


### PR DESCRIPTION
For 8x16 conv, we support NULL bias cases and cases when the bias is 64b.