### PR TITLE
Enable kernel API calls in Reorg Ops for HiFi-IQ - nne_dev

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/batch_to_space_nd.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/batch_to_space_nd.cc
@@ -85,7 +85,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<float>(output));
       break;
     case kTfLiteInt8:
-#if defined(HIFI5) || defined(HIFI4)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       {
         const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
         const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -113,7 +113,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(crops),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI5) || defined(HIFI4)
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       break;
     default:
       TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",

--- a/tensorflow/lite/micro/kernels/xtensa/depth_to_space.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depth_to_space.cc
@@ -118,7 +118,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorData<float>(output));
       break;
     case kTfLiteInt8:
-#if defined(HIFI5) || defined(HIFI4)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       {
         const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
         const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -154,7 +154,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorData<int8_t>(input),
                                   tflite::micro::GetTensorShape(output),
                                   tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI5) || defined(HIFI4)
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       break;
     default:
       TF_LITE_KERNEL_LOG(

--- a/tensorflow/lite/micro/kernels/xtensa/pad.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pad.cc
@@ -196,7 +196,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       } else {
         pad_value = *tflite::micro::GetTensorData<int8_t>(constant_values);
       }
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       if((input->dims->size <= 4))
       {
         int err;
@@ -236,7 +236,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                             tflite::micro::GetTensorData<int8_t>(output));
         }
       }
-#else // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#else // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       if (data->params.resizing_category == ResizingCategory::kImageStyle) {
         reference_ops::PadImageStyle(
             data->params, tflite::micro::GetTensorShape(input),
@@ -249,7 +249,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                            &pad_value, tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int8_t>(output));
       }
-#endif // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 #endif // defined(VISION_P6)
     } break;
     case kTfLiteInt16: {
@@ -282,7 +282,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                            tflite::micro::GetTensorData<int16_t>(output));
 #if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       }
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
     } break;
     case kTfLiteInt32: {
       int32_t pad_value =

--- a/tensorflow/lite/micro/kernels/xtensa/pad.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pad.cc
@@ -257,7 +257,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           constant_values == nullptr
               ? 0
               : *tflite::micro::GetTensorData<int16_t>(constant_values);
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       /* NNLib currently only supports up to 4D input tensors */
       if (tflite::micro::GetTensorShape(input).DimensionsCount() <= 4) {
         const TfLiteEvalTensor* paddings =
@@ -275,12 +275,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
             pad_value);
         if (err != 0) return kTfLiteError;
       } else {
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
         reference_ops::Pad(data->params, tflite::micro::GetTensorShape(input),
                            tflite::micro::GetTensorData<int16_t>(input),
                            &pad_value, tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output));
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       }
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
     } break;

--- a/tensorflow/lite/micro/kernels/xtensa/resize_bilinear.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/resize_bilinear.cc
@@ -93,7 +93,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     tflite::ResizeBilinearParams op_params;
     op_params.align_corners = params->align_corners;
     op_params.half_pixel_centers = params->half_pixel_centers;
-#if defined(HIFI5) || defined(HIFI4)
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
     const RuntimeShape input_shape =
         RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input));   
     const RuntimeShape output_size_shape =

--- a/tensorflow/lite/micro/kernels/xtensa/resize_nearest_neighbor.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/resize_nearest_neighbor.cc
@@ -90,7 +90,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int32_t>(output));
   } else if (output->type == kTfLiteInt8) {
-#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI5) || defined(HIFI4))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
 
   const RuntimeShape input_shape =
       RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input));   

--- a/tensorflow/lite/micro/kernels/xtensa/resize_nearest_neighbor.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/resize_nearest_neighbor.cc
@@ -134,6 +134,41 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         tflite::micro::GetTensorData<int8_t>(output));
 #endif        
   } else if (output->type == kTfLiteInt16) {
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+
+  const RuntimeShape input_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input));   
+  const RuntimeShape output_size_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(size));      
+  const RuntimeShape output_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+  int16_t *input_ptr = (int16_t *)(tflite::micro::GetTensorData<int16_t>(input));
+  int16_t *output_ptr = (int16_t *)(tflite::micro::GetTensorData<int16_t>(output));
+  int32_t batches = MatchingDim(input_shape, 0, output_shape, 0);
+  int32_t input_height = input_shape.Dims(1);
+  int32_t input_width = input_shape.Dims(2);
+  int32_t depth = MatchingDim(input_shape, 3, output_shape, 3);
+  int32_t output_height = tflite::micro::GetTensorData<int32_t>(size)[0];
+  int32_t output_width = tflite::micro::GetTensorData<int32_t>(size)[1];
+
+  const float height_scale =
+      (op_params.align_corners && output_height > 1)
+          ? (input_height - 1) / static_cast<float>(output_height - 1)
+          : input_height / static_cast<float>(output_height);
+
+  const float width_scale =
+      (op_params.align_corners && output_width > 1)
+          ? (input_width - 1) / static_cast<float>(output_width - 1)
+          : input_width / static_cast<float>(output_width);
+ 
+  const float offset = op_params.half_pixel_centers ? 0.5f : 0.0f;
+
+  xa_nn_resize_nearest_neighbour_16_16(output_ptr, input_ptr, batches, input_height, input_width,
+                    depth, batches, output_height, output_width, depth, height_scale, width_scale,
+                    offset, offset, op_params.align_corners);
+
+#else    
     reference_ops::ResizeNearestNeighbor(
         op_params, tflite::micro::GetTensorShape(input),
         tflite::micro::GetTensorData<int16_t>(input),
@@ -141,6 +176,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         tflite::micro::GetTensorData<int32_t>(size),
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));
+#endif        
   } else {
     MicroPrintf("Output tensor type %s (%d) not supported.",
                 TfLiteTypeGetName(output->type), output->type);

--- a/tensorflow/lite/micro/kernels/xtensa/slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/slice.cc
@@ -130,7 +130,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(output));
       break;
     case kTfLiteInt8: {
-#if defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       const RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
       const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
       const RuntimeShape extended_input_shape = RuntimeShape::ExtendedShape(5, input_shape);
@@ -173,7 +173,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int8_t>(input),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI4) || defined(HIFI5)
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       break;
     }
     case kTfLiteInt16: {

--- a/tensorflow/lite/micro/kernels/xtensa/slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/slice.cc
@@ -85,7 +85,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  int err;
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kInputTensor);
   const TfLiteEvalTensor* begin =
@@ -135,6 +134,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       const RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
       const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
       const RuntimeShape extended_input_shape = RuntimeShape::ExtendedShape(5, input_shape);
+      int err;
       
       size_t output_bytes;
       TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(output->type, &output_bytes));
@@ -177,10 +177,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteInt16: {
-#if defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       const RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
       const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
       const RuntimeShape extended_input_shape = RuntimeShape::ExtendedShape(5, input_shape);
+      int err;
 
       size_t output_bytes;
       TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(output->type, &output_bytes));
@@ -213,13 +214,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         extended_input_shape.Dims(4)
       );
       TF_LITE_ENSURE(context, err == 0);
-#else // defined(HIFI4) || defined(HIFI5)
+#else // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       reference_ops::Slice<int16_t>(
           op_params, tflite::micro::GetTensorShape(input),
           tflite::micro::GetTensorData<int16_t>(input),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int16_t>(output));
-#endif // defined(HIFI4) || defined(HIFI5)
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       break;
     }
     case kTfLiteBool:

--- a/tensorflow/lite/micro/kernels/xtensa/space_to_batch_nd.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/space_to_batch_nd.cc
@@ -94,7 +94,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<float>(output));
       break;
     case kTfLiteInt8:
-#if defined(HIFI5) || defined(HIFI4)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       {
         const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
         const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -123,7 +123,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(crops),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#endif // defined(HIFI5) || defined(HIFI4)
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       break;
     default:
       TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",

--- a/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
@@ -30,7 +30,7 @@ limitations under the License.
 namespace tflite {
 namespace {
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
 void StridedSlice_int16_hifi(const tflite::StridedSliceParams& op_params,
                              const RuntimeShape& unextended_input_shape,
                              const int16_t* input_data,
@@ -77,7 +77,8 @@ void StridedSlice_int16_hifi(const tflite::StridedSliceParams& op_params,
                             input_shape.Dims(1), input_shape.Dims(2),
                             input_shape.Dims(3), input_shape.Dims(4));
 }
-
+#endif
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
 void StridedSlice_int32_hifi(const tflite::StridedSliceParams& op_params,
                                  const RuntimeShape& unextended_input_shape,
                                  const int32_t* input_data,
@@ -124,7 +125,9 @@ void StridedSlice_int32_hifi(const tflite::StridedSliceParams& op_params,
                             input_shape.Dims(1), input_shape.Dims(2),
                             input_shape.Dims(3), input_shape.Dims(4));
 }
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
 void StridedSlice_int8_hifi(const tflite::StridedSliceParams& op_params,
                              const RuntimeShape& unextended_input_shape,
                              const int8_t* input_data,
@@ -168,7 +171,7 @@ void StridedSlice_int8_hifi(const tflite::StridedSliceParams& op_params,
       input_shape.Dims(1), input_shape.Dims(2), input_shape.Dims(3),
       input_shape.Dims(4));
 }
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
@@ -210,19 +213,19 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 #endif // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
       break;
     case kTfLiteInt16:
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if (defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       StridedSlice_int16_hifi(
           op_params, tflite::micro::GetTensorShape(input),
           tflite::micro::GetTensorData<int16_t>(input),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int16_t>(output));
-#else // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#else // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       reference_ops::StridedSlice(
           op_params, tflite::micro::GetTensorShape(input),
           tflite::micro::GetTensorData<int16_t>(input),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int16_t>(output));
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       break;
     case kTfLiteInt32:
 #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/transpose.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose.cc
@@ -100,7 +100,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                tflite::micro::GetTensorData<float>(output));
       break;
     case kTfLiteInt8 : {
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       err = xa_nn_transpose_8_8(
         tflite::micro::GetTensorData<int8_t>(output),
         tflite::micro::GetTensorShape(output).DimsData(),
@@ -116,11 +116,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                tflite::micro::GetTensorData<int8_t>(input),
                                tflite::micro::GetTensorShape(output),
                                tflite::micro::GetTensorData<int8_t>(output));
-#endif   // defined(HIFI4) || defined(HIFI5)    
+#endif   // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       }                        
       break;
     case kTfLiteInt16:
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       err = xa_nn_transpose_16_16(
         tflite::micro::GetTensorData<int16_t>(output),
         tflite::micro::GetTensorShape(output).DimsData(),


### PR DESCRIPTION
Updated following Reorg NNLib kernel API calls for HiFi-IQ core:
1. Pad
2. Resize nearest neighbor/bilinear
3. Slice/Strided slice
4. Space_to_depth/Depth_to_space
5. Transpose
6. Depth_to_space/Space_to_depth