### PR TITLE
Enable Transpose/Depthwise Conv NNLib kernel API calls for HiFi-IQ - nne_dev

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -63,9 +63,9 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 #endif
   micro_context->DeallocateTempTfLiteTensor(input);
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 
 #if defined(VISION_P6)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareVision(context, node));
@@ -74,7 +74,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)    
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
@@ -101,7 +101,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt8: {
       switch (filter_int8.type) {
         case kTfLiteInt8: {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
           return DepthwiseConvEvalInt8Hifi(context, node, params, op_data, input,
                                 &filter_int8, bias, output);
 #elif defined(VISION_P6)
@@ -109,7 +109,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   &filter_int8, bias, output);
 #else
           return DepthwiseConvReferenceEvalInt8(context, node);
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
           break;
         }
         default:
@@ -122,7 +122,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt16: {
       switch (filter->type) {
         case kTfLiteInt8: {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
           return DepthwiseConvEvalInt16Hifi(context, node, params, op_data, input,
                                 &filter_int8, bias, output);
 #else          

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
@@ -35,7 +35,7 @@ void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer,
 
 TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
   return kTfLiteOk;

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 namespace tflite {
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
                                       TfLiteNode* node) {
@@ -77,23 +77,23 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
             input_height, input_width, input_depth, filter_height, filter_width,
             depth_multiplier, stride_width, stride_height, pad_width, pad_height,
             output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
-        TF_LITE_ENSURE(context, required_scratch > 0);
         }
         else if(input->type == kTfLiteInt16){
         required_scratch = xa_nn_conv2d_depthwise_getsize(
             input_height, input_width, input_depth, filter_height, filter_width,
             depth_multiplier, stride_width, stride_height, pad_width, pad_height,
             output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
-        TF_LITE_ENSURE(context, required_scratch > 0);            
         }
-#if defined(INCLUDE_FLOAT_OPT)
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
         else if(input->type == kTfLiteFloat32){
         required_scratch = xa_nn_conv2d_depthwise_getsize(
             input_height, input_width, input_depth, filter_height, filter_width,
             depth_multiplier, stride_width, stride_height, pad_width, pad_height,
             output_height, output_width, PREC_F32, 0 /* NHWC */);
-        TF_LITE_ENSURE(context, required_scratch > 0);            
         }
+#endif       
+#ifndef HIFI_IQ
+        TF_LITE_ENSURE(context, required_scratch > 0);
 #endif       
   }
   else{
@@ -106,7 +106,7 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
       output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
       TF_LITE_ENSURE(context, required_scratch > 0);        
     }  
-#if defined(INCLUDE_FLOAT_OPT)
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
         else if(input->type == kTfLiteFloat32){
             required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
             input_height, input_width, input_depth, filter_height, filter_width,
@@ -420,7 +420,7 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
   }
 }
 
-#if defined(INCLUDE_FLOAT_OPT)
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
 TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,
@@ -563,4 +563,4 @@ TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* no
 #endif
 
 }  // namespace tflite
-#endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
@@ -26,7 +26,7 @@ namespace tflite {
 namespace {
 
 TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)    
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ) 
   const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
@@ -51,7 +51,7 @@ TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));

--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -194,7 +194,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Quantized kernels use an int32 scratch buffer.
   if (input->type == kTfLiteInt8) {
     TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
     const int stride_width = params->stride_width;
     const int stride_height = params->stride_height;
 
@@ -224,7 +224,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Quantized 16x8 kernels use an int64 scratch buffer.
   if (input->type == kTfLiteInt16) {
     TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
     const int stride_width = params->stride_width;
     const int stride_height = params->stride_height;
 
@@ -251,7 +251,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 #endif  // #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
   }
 
-#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5)) && !defined(HIFI_IQ)
   if (input->type == kTfLiteFloat32) {
     TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
     const int stride_width = params->stride_width;
@@ -367,7 +367,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                &op_params.float_activation_min,
                                &op_params.float_activation_max);
 
-#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5)) && !defined(HIFI_IQ)
       std::float_t* scratch_buffer = static_cast<float_t*>(
         context->GetScratchBuffer(context, data.scratch_buffer_index)); 
       const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
@@ -449,7 +449,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt8: {
       int32_t* scratch_buffer = static_cast<int32_t*>(
           context->GetScratchBuffer(context, data.scratch_buffer_index));
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
       const RuntimeShape& filter_shape =
           tflite::micro::GetTensorShape(filter);
@@ -483,7 +483,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       const int num_elements = output_shape.FlatSize();
 
       for (int b = 0; b < batches; b++) {
-        err = xa_nn_transpose_conv_sym8sxasym8s(
+        err = xa_nn_transpose_conv_v2_sym8sxasym8s(
           &output_data[b * output_height * output_width * output_depth],
           const_cast<WORD8*>(
               &input_data[b * input_height * input_width * input_depth]),
@@ -493,19 +493,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           filter_width, output_height, output_width, num_elements / batches,
           num_groups, data.params.input_offset, data.params.output_offset,
           data.per_channel_output_shift, data.per_channel_output_multiplier,
-          scratch_buffer
+          scratch_buffer,
+          data.params.quantized_activation_min,
+          data.params.quantized_activation_max,
+          NULL
         );
         TF_LITE_ENSURE(context, err == 0);
       }
-
-      err = xa_nn_vec_activation_min_max_8_8(
-        output_data,
-        output_data,
-        data.params.quantized_activation_min,
-        data.params.quantized_activation_max,
-        (batches * output_height * output_width * output_depth)
-      );
-      TF_LITE_ENSURE(context, err == 0);
 #else
       reference_integer_ops::TransposeConv(
           data.params, data.per_channel_output_multiplier,
@@ -569,7 +563,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
             tflite::micro::GetTensorData<int16_t>(output),
             tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);
       } else {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
         const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
         const RuntimeShape& filter_shape =
             tflite::micro::GetTensorShape(filter);
@@ -610,7 +604,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         const int num_elements = output_shape.FlatSize();
 
         for (int b = 0; b < batches; b++) {
-          err = xa_nn_transpose_conv_sym8sxsym16s(
+          err = xa_nn_transpose_conv_v2_sym8sxsym16s(
             &output_data[b * output_height * output_width * output_depth],
             const_cast<WORD16*>(
                 &input_data[b * input_height * input_width * input_depth]),
@@ -619,21 +613,15 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
             output_depth, input_height, input_width, filter_height,
             filter_width, output_height, output_width, num_elements / batches,
             num_groups, data.per_channel_output_shift, data.per_channel_output_multiplier,
-            scratch_buffer
+            scratch_buffer,
+            data.params.quantized_activation_min,
+            data.params.quantized_activation_max,
+            NULL
           );
           TF_LITE_ENSURE(context, err == 0);
         }
 
-        err = xa_nn_vec_activation_min_max_16_16(
-          output_data,
-          output_data,
-          data.params.quantized_activation_min,
-          data.params.quantized_activation_max,
-          (batches * output_height * output_width * output_depth)
-        );
-        TF_LITE_ENSURE(context, err == 0);
-
-#else  // #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#else  // #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
         reference_integer_ops::TransposeConv(
             data.params, data.per_channel_output_multiplier,
             data.per_channel_output_shift, tflite::micro::GetTensorShape(input),

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -25,7 +25,7 @@ namespace tflite {
 struct XtensaDepthwiseConvOpData {
   OpDataConv reference_op_data;
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   int scratch_tensor_index;
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
@@ -39,7 +39,7 @@ struct XtensaDepthwiseConvOpData {
 #endif  // VISION_P6
 };
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus DepthwiseConvEvalInt8Hifi(TfLiteContext* context, TfLiteNode* node,
@@ -58,7 +58,7 @@ TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node
                                    const TfLiteEvalTensor* bias,
                                    TfLiteEvalTensor* output);
 
-#if defined(INCLUDE_FLOAT_OPT)
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
 TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteDepthwiseConvParams& params,
                                    const XtensaDepthwiseConvOpData& data,
@@ -74,7 +74,7 @@ TfLiteStatus DepthwiseConvReferenceEvalInt16(TfLiteContext* context,
                                             TfLiteNode* node);
 TfLiteStatus DepthwiseConvReferenceEvalFloat32(TfLiteContext* context,
                                             TfLiteNode* node);                                                                                        
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 
 #if defined(VISION_P6)
 


### PR DESCRIPTION
Enabled Tranpose Conv and Depthwise Conv NNLib kernel API calls for HiFi-IQ core.

Adding @cad-audio and @joshih-cad as reviewers.