### PR TITLE
Enabled FC int16 and F32 precision kernel API calls for HiFi-IQ core - nne_dev

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
@@ -50,7 +50,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
   const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
 
   FullyConnectedParams op_params = FullyConnectedParamsFloat(params->activation);
-
+#ifndef HIFI_IQ
   if(num_batches == 1) {
       TF_LITE_ENSURE_EQ(
           context,
@@ -79,6 +79,31 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
           output_arr, output_arr, op_params.float_activation_min,
           op_params.float_activation_max, num_batches * output_depth),
       0);
+#else
+  if(num_batches == 1) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_fully_connected_v2_f32(
+              tflite::micro::GetTensorData<float32_t>(output),
+              tflite::micro::GetTensorData<float32_t>(filter),
+              tflite::micro::GetTensorData<float32_t>(input),
+              bias_data, accum_depth, output_depth,
+              op_params.float_activation_min, op_params.float_activation_max, NULL),
+          0);
+  }
+  else{
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_matmul_v2_f32xf32_f32(
+              tflite::micro::GetTensorData<float32_t>(output),
+              tflite::micro::GetTensorData<float32_t>(filter),
+              tflite::micro::GetTensorData<float32_t>(input),
+              bias_data, output_depth, accum_depth, accum_depth,
+              num_batches, accum_depth, output_depth, 1,
+              op_params.float_activation_min, op_params.float_activation_max, NULL),
+          0);    
+  }
+#endif // HIFI_IQ
 
 #else
 

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
@@ -36,7 +36,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto* params =
       static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
-#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
   const float32_t* bias_data =
       nullptr != bias ? tflite::micro::GetTensorData<float32_t>(bias) : nullptr;
   const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -113,7 +113,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedFloat32(
 #endif  // USE_TFLM_COMPRESSION
       tflite::micro::GetTensorShape(output),
       tflite::micro::GetTensorData<float>(output));
-#endif  // defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
@@ -40,7 +40,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedInt16(
   const int64_t* bias_data =
       nullptr != bias ? tflite::micro::GetTensorData<int64_t>(bias) : nullptr;
 
-#if defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
   const int num_batches =
       FlatSizeSkipDim(output_shape, output_shape.DimensionsCount() - 1);
@@ -122,7 +122,7 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedInt16(
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));
   }
-#endif  // defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc
@@ -126,20 +126,15 @@ TfLiteStatus XtensaEvalFullyConnectedQuantizedInt8(
       if(filter->type == kTfLiteInt4){
           TF_LITE_ENSURE_EQ(
               context,
-              xa_nn_fully_connected_asym4sxasym8s_asym8s(
+              xa_nn_fully_connected_v2_asym4sxasym8s_asym8s(
                   tflite::micro::GetTensorData<int8_t>(output),
                   filter_data,
                   tflite::micro::GetTensorData<int8_t>(input),
                   bias_data, accum_depth, output_depth, op_params.input_offset,
                   op_params.weights_offset, op_params.output_multiplier,
-                  op_params.output_shift, op_params.output_offset, p_scratch),
+                  op_params.output_shift, op_params.output_offset, p_scratch,
+                  data.output_activation_min, data.output_activation_max, NULL),
               0);
-      int8_t* output_arr = tflite::micro::GetTensorData<int8_t>(output);
-      TF_LITE_ENSURE_EQ(context,
-                      xa_nn_vec_activation_min_max_8_8(
-                          output_arr, output_arr, data.output_activation_min,
-                          data.output_activation_max, output_depth),
-                      0);
       }
       else{
 #endif       


### PR DESCRIPTION
Enabled FC int16 and F32 precision kernel API calls for HiFi-IQ core

Adding @cad-audio and @joshih-cad as reviewers.