### PR TITLE
Reverse Op Sync and ReduceMean Compatibility Fixes - nne_dev

### DIFF
--- a/tensorflow/lite/micro/kernels/reverse.cc
+++ b/tensorflow/lite/micro/kernels/reverse.cc
@@ -1,4 +1,4 @@
-/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,104 +12,93 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
-#include <stdint.h>
-#include "stdio.h"
-#include <algorithm>
 #include <array>
+#include <cstdlib>
 #include <cstring>
+#include <stdint.h>
 
-#include "tensorflow/lite/core/c/common.h"
-//#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-//#include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/reference/reverse.h"
+
+#include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
 namespace {
 
+constexpr int kMaxDimensions = RuntimeShape::kMaxSmallSize;
 constexpr int kInputTensor = 0;
 constexpr int kAxisTensor = 1;
 constexpr int kOutputTensor = 0;
 
+int comp(const void* a, const void* b) {
+  const int* int_a = static_cast<const int*>(a);
+  const int* int_b = static_cast<const int*>(b);
+  return (*int_a - *int_b);
+}
 
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+TfLiteStatus ReverseV2Prepare(TfLiteContext* context, TfLiteNode* node) {
+  MicroContext* micro_context = GetMicroContext(context);
+
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
   TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
-	
 
-  //const TfLiteTensor* input;
-  //TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kInputTensor, &input));
-  MicroContext* micro_context = GetMicroContext(context);
   TfLiteTensor* input =
       micro_context->AllocateTempInputTensor(node, kInputTensor);
   TF_LITE_ENSURE(context, input != nullptr);
-
   TfLiteTensor* axis =
       micro_context->AllocateTempInputTensor(node, kAxisTensor);
   TF_LITE_ENSURE(context, axis != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
 
-  //const TfLiteTensor* axis;
-  //TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kAxisTensor, &axis));
   TF_LITE_ENSURE_EQ(context, NumDimensions(axis), 1);
-  TF_LITE_ENSURE(context, NumDimensions(input) <= 8);
+  TF_LITE_ENSURE(context, NumDimensions(input) <= kMaxDimensions);
   TF_LITE_ENSURE(context, NumDimensions(input) >= NumElements(axis));
 
   if (input->type != kTfLiteInt32 && input->type != kTfLiteFloat32 &&
       input->type != kTfLiteUInt8 && input->type != kTfLiteInt8 &&
       input->type != kTfLiteInt16 && input->type != kTfLiteInt64 &&
       input->type != kTfLiteBool) {
-    TF_LITE_KERNEL_LOG(context, "Type '%s' is not supported by reverse.",
-                       TfLiteTypeGetName(input->type));
+    MicroPrintf("Type '%s' is not supported by reverse.",
+                TfLiteTypeGetName(input->type));
     return kTfLiteError;
   }
 
   if (axis->type != kTfLiteInt32) {
-    TF_LITE_KERNEL_LOG(context, "Axis Type '%s' is not supported by reverse.",
-                       TfLiteTypeGetName(axis->type));
+    MicroPrintf("Axis Type '%s' is not supported by reverse.",
+                TfLiteTypeGetName(axis->type));
     return kTfLiteError;
   }
 
-  TfLiteTensor* output =
-      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
-  TF_LITE_ENSURE(context, output != nullptr);
-  //TfLiteTensor* output;
-  //TF_LITE_ENSURE_OK(context,
-  //                  GetOutputSafe(context, node, kOutputTensor, &output));
-  //TfLiteIntArray* output_shape = TfLiteIntArrayCopy(input->dims);
-  TF_LITE_ENSURE_TYPES_EQ(context, output->type, input->type);
-
+  TF_LITE_ENSURE_EQ(context, input->type, output->type);
 
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(axis);
   micro_context->DeallocateTempTfLiteTensor(output);
-
   return kTfLiteOk;
 }
 
-TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  //const TfLiteTensor* input;
-  //TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kInputTensor, &input));
-  //const TfLiteTensor* axis_tensor;
-  //TF_LITE_ENSURE_OK(context,
-  //                  GetInputSafe(context, node, kAxisTensor, &axis_tensor));
+TfLiteStatus ReverseV2Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kInputTensor);
   const TfLiteEvalTensor* axis_tensor =
       tflite::micro::GetEvalInput(context, node, kAxisTensor);
-  TF_LITE_ENSURE_EQ(context, axis_tensor->type, kTfLiteInt32);
-  //const int num_axes = NumElements(axis_tensor);
-	const int num_axes = static_cast<int>(ElementCount(*axis_tensor->dims));
-  TF_LITE_ENSURE(context, num_axes <= 8);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
 
+  const int num_axes = static_cast<int>(ElementCount(*axis_tensor->dims));
+
+  // TFLite reverse implementation expects fixed size 8.
   std::array<int32_t, 8> axes;
-  memcpy(axes.data(), tflite::micro::GetTensorData<int32_t>(axis_tensor),
-         num_axes * sizeof(int32_t));
-  //const int rank = NumDimensions(input);
-	const int rank = input->dims->size;
+  std::memcpy(axes.data(), tflite::micro::GetTensorData<int32_t>(axis_tensor),
+              num_axes * sizeof(int32_t));
+
+  const int rank = tflite::micro::GetTensorShape(input).DimensionsCount();
   for (int i = 0; i < num_axes; ++i) {
     if (axes[i] < 0) {
       axes[i] += rank;
@@ -117,7 +106,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE(context, axes[i] >= 0 && axes[i] < rank);
   }
 
-  std::sort(axes.begin(), axes.begin() + num_axes);
+  // std::qsort uses the C stdlib qsort, available on all toolchains including
+  // Xtensa bare-metal, unlike std::sort which requires the libc++ runtime.
+  std::qsort(axes.data(), num_axes, sizeof(int32_t), comp);
 
   bool is_contiguous = true;
   for (int i = 1; i < num_axes; ++i) {
@@ -127,41 +118,52 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
   }
   if (!is_contiguous) {
-    TF_LITE_KERNEL_LOG(context, "Non-contiguous `axes` not supported");
+    MicroPrintf("Non-contiguous `axes` not supported");
     return kTfLiteError;
   }
 
-  //TfLiteTensor* output;
-  //TF_LITE_ENSURE_OK(context,
-  //                  GetOutputSafe(context, node, kOutputTensor, &output));
-  TfLiteEvalTensor* output =
-      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
-
   switch (output->type) {
-    case kTfLiteFloat32: {
-      reference_ops::Reverse<float>(axes, num_axes, tflite::micro::GetTensorShape(input),
-                                    tflite::micro::GetTensorData<float>(input),
-                                    tflite::micro::GetTensorData<float>(output));
+    case kTfLiteFloat32:
+      reference_ops::Reverse<float>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorData<float>(output));
       break;
-    }
+    case kTfLiteInt32:
+      reference_ops::Reverse<int32_t>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int32_t>(input),
+          tflite::micro::GetTensorData<int32_t>(output));
+      break;
+    case kTfLiteInt16:
+      reference_ops::Reverse<int16_t>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorData<int16_t>(output));
+      break;
+    case kTfLiteInt8:
     case kTfLiteUInt8:
-    case kTfLiteInt8: {
-      reference_ops::Reverse<uint8_t>(axes, num_axes, tflite::micro::GetTensorShape(input),
-                                      tflite::micro::GetTensorData<uint8_t>(input),
-                                      tflite::micro::GetTensorData<uint8_t>(output));
+      reference_ops::Reverse<uint8_t>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<uint8_t>(input),
+          tflite::micro::GetTensorData<uint8_t>(output));
       break;
-    }
-    case kTfLiteInt16: {
-      reference_ops::Reverse<int16_t>(axes, num_axes, tflite::micro::GetTensorShape(input),
-                                      tflite::micro::GetTensorData<int16_t>(input),
-                                      tflite::micro::GetTensorData<int16_t>(output));
+    case kTfLiteInt64:
+      reference_ops::Reverse<int64_t>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int64_t>(input),
+          tflite::micro::GetTensorData<int64_t>(output));
       break;
-    }
-    default: {
-      TF_LITE_KERNEL_LOG(context, "Type '%s' is not supported by reverse.",
-                         TfLiteTypeGetName(output->type));
+    case kTfLiteBool:
+      reference_ops::Reverse<bool>(
+          axes, num_axes, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<bool>(input),
+          tflite::micro::GetTensorData<bool>(output));
+      break;
+    default:
+      MicroPrintf("Output type '%s' is not supported by reverse.",
+                  TfLiteTypeGetName(output->type));
       return kTfLiteError;
-    }
   }
 
   return kTfLiteOk;
@@ -170,7 +172,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 }  // namespace
 
 TFLMRegistration Register_REVERSE_V2() {
-  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+  return tflite::micro::RegisterOp(nullptr, ReverseV2Prepare, ReverseV2Eval);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
@@ -30,7 +30,7 @@ limitations under the License.
 namespace tflite {
 
 const int kMaxNumberOfAxisHifi = 5;
-const int kMaxNumberOfReducedAxisHifi = 2;
+const int kMaxNumberOfReducedAxisHifi = 4;
 
 extern TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
                            int32_t* multiplier, int* shift);
@@ -56,7 +56,7 @@ TfLiteStatus PrepareMaxHifi(TfLiteContext* context, TfLiteNode* node,
   context->RequestScratchBufferInArena(
       context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
       &op_data->resolved_axis_idx);
-#if defined(HIFI5) || defined(HIFI4)
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
   XtensaReduceOpData* xt_data =
           reinterpret_cast<XtensaReduceOpData*>(node->user_data);
   if((input->dims->size <= 4) && (input->type == kTfLiteInt8))
@@ -113,7 +113,7 @@ TfLiteStatus PrepareMeanOrSumHifi(TfLiteContext* context, TfLiteNode* node,
     op_data->output_zp = output->params.zero_point;
     op_data->output_scale = output->params.scale;
   }
-#if defined(HIFI5) || defined(HIFI4)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   XtensaReduceOpData* xt_data =
           reinterpret_cast<XtensaReduceOpData*>(node->user_data);
   if((input->dims->size <= 4) && (input->type == kTfLiteInt8 || input->type == kTfLiteInt16))
@@ -284,7 +284,7 @@ TfLiteStatus EvalMeanHifi(TfLiteContext* context, TfLiteNode* node,
       }
     } break;
     case kTfLiteInt8: {
-#if defined(HIFI5) || defined(HIFI4)
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
       XtensaReduceOpData* xt_data =
               reinterpret_cast<XtensaReduceOpData*>(node->user_data);
       const int8_t *input_data_ptr  = tflite::micro::GetTensorData<int8_t>(input);
@@ -302,12 +302,17 @@ TfLiteStatus EvalMeanHifi(TfLiteContext* context, TfLiteNode* node,
         p_scratch = static_cast<void*>(
         context->GetScratchBuffer(context, xt_data->scratch_tensor_index));
 
+        int output_size = output->dims->size;
+        if(output_size == 0){
+          output_size = 1;
+          output->dims->data[0] = 1;
+        }
         err = xa_nn_reduce_mean_4D_asym8s_asym8s(output_data_ptr,
                                                  output->dims->data,
                                                  input_data_ptr,
                                                  input->dims->data,
                                                  resolved_axis,
-                                                 output->dims->size,
+                                                 output_size,
                                                  input->dims->size,
                                                  num_resolved_axis,
                                                  op_data->input_zp,
@@ -330,7 +335,7 @@ TfLiteStatus EvalMeanHifi(TfLiteContext* context, TfLiteNode* node,
 #endif
     } break;
     case kTfLiteInt16: {
-#if defined(HIFI5) || defined(HIFI4)
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
       XtensaReduceOpData* xt_data =
               reinterpret_cast<XtensaReduceOpData*>(node->user_data);
       const int16_t *input_data_ptr  = tflite::micro::GetTensorData<int16_t>(input);
@@ -414,7 +419,7 @@ TfLiteStatus EvalMaxHifi(TfLiteContext* context, TfLiteNode* node,
               }));
       break;
     case kTfLiteInt8: {
-#if defined(HIFI5) || defined(HIFI4)
+#if (defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4))
       XtensaReduceOpData* xt_data =
               reinterpret_cast<XtensaReduceOpData*>(node->user_data);
       const int8_t *input_data_ptr  = tflite::micro::GetTensorData<int8_t>(input);

--- a/tensorflow/lite/micro/micro_allocation_info.cc
+++ b/tensorflow/lite/micro/micro_allocation_info.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/memory_planner/greedy_memory_planner.h"
 #include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/schema/schema_utils.h"
 
 namespace tflite {
 
@@ -59,7 +60,7 @@ TfLiteStatus AllocationInfoBuilder::MarkSubgraphLifetimesIfNecessary(
   int second_subgraph_index = -1;
   const OperatorCode* opcode =
       model_->operator_codes()->Get(op->opcode_index());
-  switch (opcode->builtin_code()) {
+  switch (GetBuiltinCode(opcode)) {
     case BuiltinOperator_IF: {
       first_subgraph_index =
           op->builtin_options_as_IfOptions()->then_subgraph_index();


### PR DESCRIPTION
Updates:
	1. Absorbed reverse.cc from master TFLM repository.
	2. Updated kMaxNumberOfReducedAxisHifi to 4, implemented logic to handle output->dims->size==0 case for REDUCE_MEAN 8-bit implementation.
	3. Used GetBuiltinCode() wrapper function instead of opcode->builtin_code() function to ensure opcode read compatibility between the TFLite v3 and v3a schema versions.